### PR TITLE
Added parent link name instead of Back in sub mobile menu

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -2,8 +2,6 @@
 {{ "mega-menu.css" | asset_url | stylesheet_tag }}
 
 {%- assign search_placeholder    = section.settings.search_placeholder -%}
-{%- assign login_placeholder     = section.settings.login_placeholder -%}
-{%- assign signup_placeholder    = section.settings.signup_placeholder -%}
 {%- assign logo                  = section.settings.logo -%}
 {%- assign logo_vector           = section.settings.logo_vector -%}
 {%- assign custom_title          = section.settings.custom_title -%}
@@ -350,18 +348,6 @@
         "id": "search_placeholder",
         "label": "Search placeholder",
         "default": "Search"
-      },
-      {
-        "type": "text",
-        "id": "login_placeholder",
-        "label": "'Login button' label",
-        "default": "Log in"
-      },
-      {
-        "type": "text",
-        "id": "signup_placeholder",
-        "label": "'Create account' button label",
-        "default": "Create account"
       },
       {
         "type": "image_picker",


### PR DESCRIPTION
1. Added parent link name instead of "Back" in sub mobile menu
2. Removed unneeded elements in the theme editor sidebar