### PR TITLE
Added "Alternative background" and "Alternative color" to theme settings

### DIFF
--- a/assets/account.css
+++ b/assets/account.css
@@ -301,7 +301,7 @@
 }
 
 .palette-one .account-fieldset--error .account-fieldset__label {
-  background:  linear-gradient(0deg, var(--color-light-red, #F5CFCF) 0%, var(--color-light-red, #F5CFCF) 48%, transparent 48%);
+  background:  linear-gradient(0deg, var(--color-red-light, #F5CFCF) 0%, var(--color-red-light, #F5CFCF) 48%, transparent 48%);
   color: var(--color-red, #C23434);
 }
 
@@ -311,7 +311,7 @@
 }
 
 .palette-one .account-fieldset--error .account-fieldset__input {
-  background-color: var(--color-light-red, #F5CFCF);
+  background-color: var(--color-red-light, #F5CFCF);
   border-color: var(--color-red, #C23434);
   color: var(--color-red, #C23434);
 }
@@ -405,18 +405,18 @@
 
 .palette-two .account-fieldset--error .account-fieldset__label {
   background:  linear-gradient(0deg, var(--color-alabama-crimson, #B40030) 0%, var(--color-alabama-crimson, #B40030) 48%, transparent 48%);
-  color: var(--color-light-red, #F5CFCF);
+  color: var(--color-red-light, #F5CFCF);
 }
 
 .palette-two .account__error-message,
 .palette-two .account-fieldset--error .account-fieldset__static-label {
-  color: var(--color-light-red, #F5CFCF);
+  color: var(--color-red-light, #F5CFCF);
 }
 
 .palette-two .account-fieldset--error .account-fieldset__input {
   background-color: var(--color-alabama-crimson, #B40030);
-  border-color: var(--color-light-red, #F5CFCF);
-  color: var(--color-light-red, #F5CFCF);
+  border-color: var(--color-red-light, #F5CFCF);
+  color: var(--color-red-light, #F5CFCF);
 }
 
 @media screen and (min-width: 375px) {

--- a/assets/base.css
+++ b/assets/base.css
@@ -21,22 +21,13 @@
   /* Colors */
   --color-alabama-crimson: #B40030;
   --color-azureish-white: #D7E2FF;
-  --color-black: #0B1A26;
-  --color-black-00: #0B1A2600;
-  --color-black-08: #0B1A2614;
-  --color-black-45: #0B1A2673;
-  --color-black-90: #0B1A26E6;
-  --color-dark-gray: #0B1A2659;
-  --color-green: #51C234;
-  --color-red: #C23434;
-  --color-light-red: #F5CFCF;
   --color-begonia: #FF6E6E;
+  --color-black: #0B1A26;
+  --color-black-08: #0B1A2614;
+  --color-red: #C23434;
+  --color-red-light: #F5CFCF;
   --color-white: #FFFFFF;
-  --color-white-00: #FFFFFF00;
-  --color-white-08: #FFFFFF14;
-  --color-white-45: #FFFFFF73;
   --color-white-90: #FFFFFFE6;
-  --color-white-gray: #FFFFFF59;
 
   /* Font weights */
   --font-weight-light: 300;

--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -317,54 +317,98 @@
   fill: var(--color-primary-2, #FFFFFF);
 }
 
-.overlay-light .carousel__edges .carousel__btn,
+.palette-one .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn,
 .palette-one .carousel__edges .carousel__btn {
-  background: var(--color-black-08, #0B1A2614);
+  background: var(--background-overlay-08, #0B1A2614);
+  border-color: transparent;
 }
 
-.overlay-light .carousel__edges .carousel__btn path,
+.palette-one .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn {
+  background: var(--color-overlay-08, #FFFFFF14);
+  border-color: transparent;
+}
+
+.palette-one .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn path,
 .palette-one .carousel__edges .carousel__btn path {
-  fill: var(--color-black, #0B1A26);
+  fill: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light .carousel__edges .carousel__dot:after,
+.palette-one .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn path {
+  fill: var(--color-overlay, #FFFFFF);
+}
+
+.palette-one .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot:after,
 .palette-one .carousel__edges .carousel__dot:after {
-  background: var(--color-black-45, #0B1A2673);
+  background: var(--background-overlay-45, #0B1A2673);
 }
 
-.overlay-light .carousel__edges .carousel__dot.active:after,
+.palette-one .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot:after {
+  background: var(--color-overlay-45, #FFFFFF73);
+}
+
+.palette-one .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot.active:after,
 .palette-one .carousel__edges .carousel__dot.active:after {
-  background: var(--color-black, #0B1A26);
+  background: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light .carousel__edges .carousel__counter,
+.palette-one .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot.active:after {
+  background: var(--color-overlay, #FFFFFF);
+}
+
+.palette-one .carousel__edges .show-overlay-light ~ .carousel__counter,
 .palette-one .carousel__edges .carousel__counter {
-  color: var(--color-black, #0B1A26);
+  color: var(--background-overlay, #0B1A26);
 }
 
-.overlay-dark .carousel__edges .carousel__btn,
+.palette-one .carousel__edges .show-overlay-dark ~ .carousel__counter {
+  color: var(--color-overlay, #FFFFFF);
+}
+
+.palette-two .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn,
 .palette-two .carousel__edges .carousel__btn {
-  background: var(--color-white-08, #FFFFFF14);
+  background: var(--background-overlay-2-08, #0B1A2614);
+  border-color: transparent;
 }
 
-.overlay-dark .carousel__edges .carousel__btn path,
+.palette-two .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn {
+  background: var(--color-overlay-2-08, #FFFFFF14);
+  border-color: transparent;
+}
+
+.palette-two .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn path,
 .palette-two .carousel__edges .carousel__btn path {
-  fill: var(--color-white, #FFFFFF);
+  fill: var(--background-overlay-2, #0B1A26);
 }
 
-.overlay-dark .carousel__edges .carousel__dot:after,
+.palette-two .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn path {
+  fill: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot:after,
 .palette-two .carousel__edges .carousel__dot:after {
-  background: var(--color-white-45, #FFFFFF73);
+  background: var(--background-overlay-2-45, #0B1A2673);
 }
 
-.overlay-dark .carousel__edges .carousel__dot.active:after,
+.palette-two .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot:after {
+  background: var(--color-overlay-2-45, #FFFFFF73);
+}
+
+.palette-two .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot.active:after,
 .palette-two .carousel__edges .carousel__dot.active:after {
-  background: var(--color-white, #FFFFFF);
+  background: var(--background-overlay-2, #0B1A26);
 }
 
-.overlay-dark .carousel__edges .carousel__counter,
+.palette-two .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot.active:after {
+  background: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two .carousel__edges .show-overlay-light ~ .carousel__counter,
 .palette-two .carousel__edges .carousel__counter {
-  color: var(--color-white, #FFFFFF);
+  color: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two .carousel__edges .show-overlay-dark ~ .carousel__counter {
+  color: var(--color-overlay-2, #FFFFFF);
 }
 
 @media (min-width: 992px) {
@@ -467,7 +511,6 @@
     background: var(--color-primary, #0B1A26);
   }
 
-
   .palette-two .carousel__btn:hover {
     border-color: var(--color-primary-2, #FFFFFF);
   }
@@ -476,23 +519,39 @@
     background: var(--color-primary-2, #FFFFFF);
   }
 
-  .overlay-light .carousel__edges .carousel__btn:hover,
+  .palette-one .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn:hover,
   .palette-one .carousel__edges .carousel__btn:hover {
-    border-color: var(--color-black, #0B1A26);
+    border-color: var(--background-overlay, #0B1A26);
   }
 
-  .overlay-light .carousel__edges .carousel__dot:hover:after,
+  .palette-one .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn:hover {
+    border-color: var(--color-overlay, #FFFFFF);
+  }
+
+  .palette-one .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot:hover:after,
   .palette-one .carousel__edges .carousel__dot:hover:after {
-    background: var(--color-black, #0B1A26);
+    background: var(--background-overlay, #0B1A26);
   }
 
-  .overlay-dark .carousel__edges .carousel__btn:hover,
+  .palette-one .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot:hover:after {
+    background: var(--color-overlay, #FFFFFF);
+  }
+
+  .palette-two .carousel__edges .show-overlay-light ~ .carousel__navigation .carousel__btn:hover,
   .palette-two .carousel__edges .carousel__btn:hover {
-    border-color: var(--color-white, #FFFFFF);
+    border-color: var(--background-overlay-2, #0B1A26);
   }
 
-  .overlay-dark .carousel__edges .carousel__dot:hover:after,
+  .palette-two .carousel__edges .show-overlay-dark ~ .carousel__navigation .carousel__btn:hover {
+    border-color: var(--color-overlay-2, #FFFFFF);
+  }
+
+  .palette-two .carousel__edges .show-overlay-light ~ .carousel__pagination .carousel__dot:hover:after,
   .palette-two .carousel__edges .carousel__dot:hover:after {
-    background: var(--color-white, #FFFFFF);
+    background: var(--background-overlay-2, #0B1A26);
+  }
+
+  .palette-two .carousel__edges .show-overlay-dark ~ .carousel__pagination .carousel__dot:hover:after {
+    background: var(--color-overlay-2, #FFFFFF);
   }
 }

--- a/assets/carousel.js
+++ b/assets/carousel.js
@@ -19,11 +19,16 @@ class Carousel {
       show: "show",
       fade: "carousel__fade-effect",
       full: "carousel__full-width",
+      edges: "carousel__edges",
       pause: "carousel__pause",
       dot: "carousel__dot",
       prev: "prev",
       next: "next",
-      init: "initialized"
+      init: "initialized",
+      dark: "overlay-dark",
+      light: "overlay-light",
+      showDark: "show-overlay-dark",
+      showLight: "show-overlay-light"
     }
 
     this.modifiers = {
@@ -80,6 +85,7 @@ class Carousel {
     this.pauseAutoRotate();
     this.hideControls();
     this.hidePaginationDots();
+    this.setOverlay(1);
 
     this.listener(this.dots, 'click', this.pagination);
     this.listener(this.dots, 'click', this.navigation);
@@ -334,6 +340,7 @@ class Carousel {
 
     this.counter(index);
     this.fadeClass(index);
+    this.setOverlay(index);
   }
 
   // hide not used dots of the pagination
@@ -465,6 +472,45 @@ class Carousel {
     })
 
     return {index, dots};
+  }
+
+  // add/change overlay class to change colors of navigation/pagination buttons of images carousel with overlay
+  setOverlay(index) {
+    const isEdge = this.block.classList.contains(this.classes.edges);
+
+    if (!isEdge || !index || index > this.items.length) return false;
+
+    this.items.forEach((item, itemIndex) => {
+      const isLight = item.classList.contains(this.classes.light),
+            isDark = item.classList.contains(this.classes.dark);
+
+      const optionsLight = {
+        addClass: this.classes.showLight,
+        oldClass: this.classes.showDark,
+        newClass: this.classes.showLight
+      }
+
+      const optionsDark = {
+        addClass: this.classes.showDark,
+        oldClass: this.classes.showLight,
+        newClass: this.classes.showDark
+      }
+
+      if (itemIndex + 1 === index) {
+        if (isLight) this.setClass(this.wrap, optionsLight)
+        if (isDark) this.setClass(this.wrap, optionsDark)
+      }
+    })
+  }
+
+  setClass(element, options) {
+    const {addClass, oldClass, newClass} = options,
+          isOld = element.classList.contains(oldClass),
+          isNew = element.classList.contains(newClass);
+
+    !isOld && !isNew
+      ? element.classList.add(addClass)
+      : element.classList.replace(oldClass, newClass)
   }
 
   scrollTo(options) {

--- a/assets/collections.css
+++ b/assets/collections.css
@@ -112,28 +112,52 @@
   background: var(--color-image-placeholder-2, #FFFFFF47);
 }
 
-.overlay-dark .collections__heading {
-  color: var(--color-white, #FFFFFF);
+.palette-one.overlay-dark .collections__heading {
+  color: var(--color-overlay, #FFFFFF);
 }
 
-.overlay-dark .collections__link .collections__image-item:before {
-  background: linear-gradient(0.13deg, var(--color-black, #0B1A26) 8.87%, var(--color-black-00, #0B1A2600) 95.37%);
+.palette-one.overlay-dark .collections__link .collections__image-item:before {
+  background: linear-gradient(0.13deg, var(--background-overlay, #0B1A26) 8.87%, var(--background-overlay-00, #0B1A2600) 95.37%);
 }
 
-.overlay-dark .collections__link .collections__image-item:after {
-  background: var(--color-black, #0B1A26);
+.palette-one.overlay-dark .collections__link .collections__image-item:after {
+  background: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light .collections__heading {
-  color: var(--color-black, #0B1A26);
+.palette-one.overlay-light .collections__heading {
+  color: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light .collections__link .collections__image-item:before {
-  background: linear-gradient(0.13deg, var(--color-white, #FFFFFF) 8.87%, var(--color-white-00, #FFFFFF00) 95.37%);
+.palette-one.overlay-light .collections__link .collections__image-item:before {
+  background: linear-gradient(0.13deg, var(--color-overlay, #FFFFFF) 8.87%, var(--color-overlay-00, #FFFFFF00) 95.37%);
 }
 
-.overlay-light .collections__link .collections__image-item:after {
-  background: var(--color-white, #FFFFFF);
+.palette-one.overlay-light .collections__link .collections__image-item:after {
+  background: var(--color-overlay, #FFFFFF);
+}
+
+.palette-two.overlay-dark .collections__heading {
+  color: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two.overlay-dark .collections__link .collections__image-item:before {
+  background: linear-gradient(0.13deg, var(--background-overlay-2, #0B1A26) 8.87%, var(--background-overlay-2-00, #0B1A2600) 95.37%);
+}
+
+.palette-two.overlay-dark .collections__link .collections__image-item:after {
+  background: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two.overlay-light .collections__heading {
+  color: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two.overlay-light .collections__link .collections__image-item:before {
+  background: linear-gradient(0.13deg, var(--color-overlay-2, #FFFFFF) 8.87%, var(--color-overlay-2-00, #FFFFFF00) 95.37%);
+}
+
+.palette-two.overlay-light .collections__link .collections__image-item:after {
+  background: var(--color-overlay-2, #FFFFFF);
 }
 
 @media (min-width: 768px) {

--- a/assets/images.css
+++ b/assets/images.css
@@ -99,48 +99,100 @@
   scroll-padding: 0;
 }
 
-.overlay-dark .images__title {
-  color: var(--color-white, #FFFFFF);
+.palette-one .overlay-dark .images__title {
+  color: var(--color-overlay, #FFFFFF);
 }
 
-.overlay-dark .images__description {
-  color: var(--color-white-gray, #FFFFFF59);
+.palette-one .overlay-dark .images__description {
+  color: var(--color-overlay-gray, #FFFFFF59);
 }
 
-.overlay-dark .images__buttons .button--outlined {
-  color: var(--color-white, #FFFFFF);
+.palette-one .overlay-dark .images__buttons .button--outlined {
+  color: var(--color-overlay, #FFFFFF);
 }
 
-.overlay-dark ~ .images__vision {
-  background: var(--color-black, #0B1A26);
+.palette-one .overlay-dark .images__vision,
+.palette-one .overlay-dark ~ .images__vision {
+  background: var(--background-overlay, #0B1A26);
 }
 
-.overlay-dark ~ .images__vision .images__vision-wrapper--overlay:after {
-  background: linear-gradient(357.73deg, var(--color-black, #0B1A26) 3.03%, var(--color-black-00, #0B1A2600) 31.83%),
-   linear-gradient(180deg, var(--color-black, #0B1A26) 6.67%, var(--color-black-00, #0B1A2600) 105.81%),
-   linear-gradient(0deg, var(--color-black-45, #0B1A2673), var(--color-black-45, #0B1A2673));
+.palette-one .overlay-dark .images__vision .images__vision-wrapper--overlay:after,
+.palette-one .overlay-dark ~ .images__vision .images__vision-wrapper--overlay:after {
+  background: linear-gradient(357.73deg, var(--background-overlay, #0B1A26) 3.03%, var(--background-overlay-00, #0B1A2600) 31.83%),
+   linear-gradient(180deg, var(--background-overlay, #0B1A26) 6.67%, var(--background-overlay-00, #0B1A2600) 105.81%),
+   linear-gradient(0deg, var(--background-overlay-45, #0B1A2673), var(--background-overlay-45, #0B1A2673));
 }
 
-.overlay-light .images__title {
-  color: var(--color-black, #0B1A26);
+.palette-one .overlay-light .images__title {
+  color: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light .images__description {
-  color: var(--color-dark-gray, #0B1A2659);
+.palette-one .overlay-light .images__description {
+  color: var(--background-overlay-gray, #0B1A2659);
 }
 
-.overlay-light .images__buttons .button--outlined {
-  color: var(--color-black, #0B1A26);
+.palette-one .overlay-light .images__buttons .button--outlined {
+  color: var(--background-overlay, #0B1A26);
 }
 
-.overlay-light ~ .images__vision {
-  background: var(--color-white, #FFFFFF);
+.palette-one .overlay-light .images__vision,
+.palette-one .overlay-light ~ .images__vision {
+  background: var(--color-overlay, #FFFFFF);
 }
 
-.overlay-light ~ .images__vision .images__vision-wrapper--overlay:after {
-  background: linear-gradient(357.73deg, var(--color-white, #FFFFFF) 3.03%, var(--color-white-00, #FFFFFF00) 31.83%),
-   linear-gradient(180deg, var(--color-white, #FFFFFF) 6.67%, var(--color-white-00, #FFFFFF00) 105.81%),
-   linear-gradient(0deg, var(--color-white-45, #FFFFFF73), var(--color-white-45, #FFFFFF73));
+.palette-one .overlay-light .images__vision .images__vision-wrapper--overlay:after,
+.palette-one .overlay-light ~ .images__vision .images__vision-wrapper--overlay:after {
+  background: linear-gradient(357.73deg, var(--color-overlay, #FFFFFF) 3.03%, var(--color-overlay-00, #FFFFFF00) 31.83%),
+   linear-gradient(180deg, var(--color-overlay, #FFFFFF) 6.67%, var(--color-overlay-00, #FFFFFF00) 105.81%),
+   linear-gradient(0deg, var(--color-overlay-45, #FFFFFF73), var(--color-overlay-45, #FFFFFF73));
+}
+
+.palette-two .overlay-dark .images__title {
+  color: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two .overlay-dark .images__description {
+  color: var(--color-overlay-2-gray, #FFFFFF59);
+}
+
+.palette-two .overlay-dark .images__buttons .button--outlined {
+  color: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two .overlay-dark .images__vision,
+.palette-two .overlay-dark ~ .images__vision {
+  background: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two .overlay-dark .images__vision .images__vision-wrapper--overlay:after,
+.palette-two .overlay-dark ~ .images__vision .images__vision-wrapper--overlay:after {
+  background: linear-gradient(357.73deg, var(--background-overlay-2, #0B1A26) 3.03%, var(--background-overlay-2-00, #0B1A2600) 31.83%),
+   linear-gradient(180deg, var(--background-overlay-2, #0B1A26) 6.67%, var(--background-overlay-2-00, #0B1A2600) 105.81%),
+   linear-gradient(0deg, var(--background-overlay-2-45, #0B1A2673), var(--background-overlay-2-45, #0B1A2673));
+}
+
+.palette-two .overlay-light .images__title {
+  color: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two .overlay-light .images__description {
+  color: var(--background-overlay-2-gray, #0B1A2659);
+}
+
+.palette-two .overlay-light .images__buttons .button--outlined {
+  color: var(--background-overlay-2, #0B1A26);
+}
+
+.palette-two .overlay-light .images__vision,
+.palette-two .overlay-light ~ .images__vision {
+  background: var(--color-overlay-2, #FFFFFF);
+}
+
+.palette-two .overlay-light .images__vision .images__vision-wrapper--overlay:after,
+.palette-two .overlay-light ~ .images__vision .images__vision-wrapper--overlay:after {
+  background: linear-gradient(357.73deg, var(--color-overlay-2, #FFFFFF) 3.03%, var(--color-overlay-2-00, #FFFFFF00) 31.83%),
+   linear-gradient(180deg, var(--color-overlay-2, #FFFFFF) 6.67%, var(--color-overlay-2-00, #FFFFFF00) 105.81%),
+   linear-gradient(0deg, var(--color-overlay-2-45, #FFFFFF73), var(--color-overlay-2-45, #FFFFFF73));
 }
 
 @media (min-width: 428px) {

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -8,7 +8,7 @@
         "settings": {
           "bar_message": "Free shipping from €50",
           "bar_text": "Call Us 24/7 <a href=\"+1 755 302 8549\">+1 755 302 8549</a>",
-          "color_palette": "two",
+          "color_palette": "one",
           "icon": "phone",
           "padding_top": "medium",
           "padding_top_mobile": "medium",
@@ -22,11 +22,11 @@
         "blocks": {},
         "block_order": [],
         "settings": {
-          "color_palette": "one",
+          "color_palette": "two",
           "custom_title": "{{ shop.name }}",
-          "logo": "booqable://assets/image-store-logo-black.png",
+          "logo": "booqable://assets/image-store-logo-white.png",
           "menu": "main-menu",
-          "menu_opener_mobile": "right",
+          "menu_opener_mobile": "left",
           "menu_style": "horizontal",
           "menu_position": "left-center",
           "menu_position_mobile": "top",

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -8,7 +8,7 @@
         "settings": {
           "bar_message": "Free shipping from €50",
           "bar_text": "Call Us 24/7 <a href=\"+1 755 302 8549\">+1 755 302 8549</a>",
-          "color_palette": "one",
+          "color_palette": "two",
           "icon": "phone",
           "padding_top": "medium",
           "padding_top_mobile": "medium",
@@ -22,11 +22,11 @@
         "blocks": {},
         "block_order": [],
         "settings": {
-          "color_palette": "two",
+          "color_palette": "one",
           "custom_title": "{{ shop.name }}",
-          "logo": "booqable://assets/image-store-logo-white.png",
+          "logo": "booqable://assets/image-store-logo-black.png",
           "menu": "main-menu",
-          "menu_opener_mobile": "left",
+          "menu_opener_mobile": "right",
           "menu_style": "horizontal",
           "menu_position": "left-center",
           "menu_position_mobile": "top",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -26,41 +26,41 @@
         "type": "color",
         "id": "primary_color",
         "label": "Primary text",
-        "default": "#231905"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
         "id": "secondary_color",
         "label": "Secondary text",
-        "default": "#A69F98"
+        "default": "#4E5D78"
       },
       {
         "type": "color",
         "id": "accent_background",
         "label": "Accent background",
         "info": "Used as a background of solid buttons, date picker, etc.",
-        "default": "#BA975D"
+        "default": "#F4B841"
       },
       {
         "type": "color",
         "id": "accent_color",
         "label": "Accent text",
         "info": "Used for text on top of the accent background",
-        "default": "#231905"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
         "id": "accent_outline",
         "label": "Accent outline",
         "info": "Also used for accent text without background",
-        "default": "#BA975D"
+        "default": "#F4B841"
       },
       {
         "type": "color",
         "id": "overlay_background",
         "label": "Alternative background",
         "info": "Used to make text readable on top of the background images",
-        "default": "#150902"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
@@ -77,47 +77,47 @@
         "type": "color",
         "id": "background_2",
         "label": "Background",
-        "default": "#E3DAD0"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
         "id": "primary_color_2",
         "label": "Primary text",
-        "default": "#231905"
+        "default": "#FFFFFF"
       },
       {
         "type": "color",
         "id": "secondary_color_2",
         "label": "Secondary text",
-        "default": "#A69F98"
+        "default": "#E1E4E8"
       },
       {
         "type": "color",
         "id": "accent_background_2",
         "label": "Accent background",
         "info": "Used as a background of solid buttons, date picker, etc.",
-        "default": "#BA975D"
+        "default": "#F4B841"
       },
       {
         "type": "color",
         "id": "accent_color_2",
         "label": "Accent text",
         "info": "Used for text on top of the accent background",
-        "default": "#231905"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
         "id": "accent_outline_2",
         "label": "Accent outline",
         "info": "Also used for accent text without background",
-        "default": "#BA975D"
+        "default": "#F4B841"
       },
       {
         "type": "color",
         "id": "overlay_background_2",
         "label": "Alternative background",
         "info": "Used to make text readable on top of the background images",
-        "default": "#150902"
+        "default": "#0B1A26"
       },
       {
         "type": "color",
@@ -140,21 +140,21 @@
         "id": "heading_font",
         "label": "Heading",
         "info": "Font used for headers",
-        "default": "bona-nova"
+        "default": "barlow"
       },
       {
         "type": "font_picker",
         "id": "body_font",
         "label": "Body",
         "info": "Font used for texts",
-        "default": "poppins"
+        "default": "barlow"
       },
       {
         "type": "font_picker",
         "id": "tagline_font",
         "label": "Tagline",
         "info": "Font used for taglines",
-        "default": "dancing-script"
+        "default": "barlow"
       },
       {
         "type": "header",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -26,34 +26,48 @@
         "type": "color",
         "id": "primary_color",
         "label": "Primary text",
-        "default": "#0B1A26"
+        "default": "#231905"
       },
       {
         "type": "color",
         "id": "secondary_color",
         "label": "Secondary text",
-        "default": "#4E5D78"
+        "default": "#A69F98"
       },
       {
         "type": "color",
         "id": "accent_background",
         "label": "Accent background",
         "info": "Used as a background of solid buttons, date picker, etc.",
-        "default": "#F4B841"
+        "default": "#BA975D"
       },
       {
         "type": "color",
         "id": "accent_color",
         "label": "Accent text",
         "info": "Used for text on top of the accent background",
-        "default": "#0B1A26"
+        "default": "#231905"
       },
       {
         "type": "color",
         "id": "accent_outline",
         "label": "Accent outline",
         "info": "Also used for accent text without background",
-        "default": "#F4B841"
+        "default": "#BA975D"
+      },
+      {
+        "type": "color",
+        "id": "overlay_background",
+        "label": "Alternative background",
+        "info": "Used to make text readable on top of the background images",
+        "default": "#150902"
+      },
+      {
+        "type": "color",
+        "id": "overlay_color",
+        "label": "Alternative color",
+        "info": "Used for text on top of the background images",
+        "default": "#FFFFFF"
       },
       {
         "type": "header",
@@ -63,40 +77,54 @@
         "type": "color",
         "id": "background_2",
         "label": "Background",
-        "default": "#0B1A26"
+        "default": "#E3DAD0"
       },
       {
         "type": "color",
         "id": "primary_color_2",
         "label": "Primary text",
-        "default": "#FFFFFF"
+        "default": "#231905"
       },
       {
         "type": "color",
         "id": "secondary_color_2",
         "label": "Secondary text",
-        "default": "#E1E4E8"
+        "default": "#A69F98"
       },
       {
         "type": "color",
         "id": "accent_background_2",
         "label": "Accent background",
         "info": "Used as a background of solid buttons, date picker, etc.",
-        "default": "#F4B841"
+        "default": "#BA975D"
       },
       {
         "type": "color",
         "id": "accent_color_2",
         "label": "Accent text",
         "info": "Used for text on top of the accent background",
-        "default": "#0B1A26"
+        "default": "#231905"
       },
       {
         "type": "color",
         "id": "accent_outline_2",
         "label": "Accent outline",
         "info": "Also used for accent text without background",
-        "default": "#F4B841"
+        "default": "#BA975D"
+      },
+      {
+        "type": "color",
+        "id": "overlay_background_2",
+        "label": "Alternative background",
+        "info": "Used to make text readable on top of the background images",
+        "default": "#150902"
+      },
+      {
+        "type": "color",
+        "id": "overlay_color_2",
+        "label": "Alternative color",
+        "info": "Used for text on top of the background images",
+        "default": "#FFFFFF"
       }
     ]
   },
@@ -112,21 +140,21 @@
         "id": "heading_font",
         "label": "Heading",
         "info": "Font used for headers",
-        "default": "barlow"
+        "default": "bona-nova"
       },
       {
         "type": "font_picker",
         "id": "body_font",
         "label": "Body",
         "info": "Font used for texts",
-        "default": "barlow"
+        "default": "poppins"
       },
       {
         "type": "font_picker",
         "id": "tagline_font",
         "label": "Tagline",
         "info": "Font used for taglines",
-        "default": "barlow"
+        "default": "dancing-script"
       },
       {
         "type": "header",

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -279,11 +279,11 @@
             {% comment %} CSS variables end {% endcomment %}
 
             {%- if carousel -%}
-              <div class="carousel__item{% if effect == 'fade' and first == false %} hide{% endif %}{% if effect == 'fade' and first %} show{%- endif -%}">
+              <div class="carousel__item overlay-{{ color_overlay }}{% if effect == 'fade' and first == false %} hide{% endif %}{% if effect == 'fade' and first %} show{%- endif -%}">
                 <div class="carousel__inner">
             {%- endif -%}
                   <div
-                    class="images__container container{% if color_overlay != blank %} overlay-{{ color_overlay }}{% endif %}{% if padding_top != blank or padding_top_mobile != blank %} images__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} images__container--padding-bottom{%  endif %}"
+                    class="images__container container{% unless carousel %} overlay-{{ color_overlay }}{% endunless %}{% if padding_top != blank or padding_top_mobile != blank %} images__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} images__container--padding-bottom{%  endif %}"
                     style="{{- text_variables | escape -}}"
                   >
                     <div class="images__text-area">

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -58,6 +58,22 @@
       --color-outline-active: {{- branding_color | append: "BA" -}};
     {%- endif -%}
 
+    {%- if settings.overlay_background != blank -%}
+      --background-overlay: {{- settings.overlay_background -}};
+      --background-overlay-00: {{- settings.overlay_background | append: "00" -}};
+      --background-overlay-08: {{- settings.overlay_background | append: "14" -}};
+      --background-overlay-45: {{- settings.overlay_background | append: "73" -}};
+      --background-overlay-gray: {{- settings.overlay_background | append: "59" -}};
+    {%- endif -%}
+
+    {%- if settings.overlay_color != blank -%}
+      --color-overlay: {{- settings.overlay_color -}};
+      --color-overlay-00: {{- settings.overlay_color | append: "00" -}};
+      --color-overlay-08: {{- settings.overlay_color | append: "14" -}};
+      --color-overlay-45: {{- settings.overlay_color | append: "73" -}};
+      --color-overlay-gray: {{- settings.overlay_color | append: "59" -}};
+    {%- endif -%}
+
     {%- if settings.background_2 != blank -%}
       --background-primary-2: {{- settings.background_2 -}};
       --background-primary-2-00: {{- settings.background_2 | append: "00" -}};
@@ -114,6 +130,22 @@
       --color-outline-2: {{- branding_color -}};
       --color-outline-2-hover: {{- branding_color | append: "CC" -}};
       --color-outline-2-active: {{- branding_color | append: "BA" -}};
+    {%- endif -%}
+
+    {%- if settings.overlay_background_2 != blank -%}
+      --background-overlay-2: {{- settings.overlay_background_2 -}};
+      --background-overlay-2-00: {{- settings.overlay_background_2 | append: "00" -}};
+      --background-overlay-2-08: {{- settings.overlay_background_2 | append: "14" -}};
+      --background-overlay-2-45: {{- settings.overlay_background_2 | append: "73" -}};
+      --background-overlay-2-gray: {{- settings.overlay_background_2 | append: "59" -}};
+    {%- endif -%}
+
+    {%- if settings.overlay_color_2 != blank -%}
+      --color-overlay-2: {{- settings.overlay_color_2 -}};
+      --color-overlay-2-00: {{- settings.overlay_color_2 | append: "00" -}};
+      --color-overlay-2-08: {{- settings.overlay_color_2 | append: "14" -}};
+      --color-overlay-2-45: {{- settings.overlay_color_2 | append: "73" -}};
+      --color-overlay-2-gray: {{- settings.overlay_color_2 | append: "59" -}};
     {%- endif -%}
 
     {%- if settings.heading_font != blank -%}


### PR DESCRIPTION
At the moment there are 2 overlay colors in Tough theme: black and white. These colors were set up via static CSS variables and the Romantic theme has a different black color, so the customers should have the possibility to edit these 2 colors

What should be done:

- Add 2 extra color pickers to each color set to settings_schema.json
- Make sure that navigation buttons/dots are visible on top of the overlay background when the overlay background is different on other slides

Changelog: 
1. Added some logic to the carousel.js file
2. Added 2 extra color pickers to each color set to theme settings
3. Slightly changed the logic of full-width carousel in the Hero section on Homepage
4. Added styles to sections that have images with overlays
5. Claned up CSS variables 


Before: 
![Google Chrome_2023-09-12 10-22-33@2x](https://github.com/booqable/tough-theme/assets/40244261/bcd08d6a-b410-41cb-94d1-c691c3a99976)
![Google Chrome_2023-09-12 10-23-00@2x](https://github.com/booqable/tough-theme/assets/40244261/a6a8232b-0270-4db7-8ac2-09dc71612e0c)

After:
![Google Chrome_2023-09-12 16-00-09@2x](https://github.com/booqable/tough-theme/assets/40244261/c5671f7c-7ed2-4191-b677-63eab700a403)
![Google Chrome_2023-09-12 16-02-07@2x](https://github.com/booqable/tough-theme/assets/40244261/9b8c9419-70e2-4976-9f83-1a44c4de0c1d)

