### PR TITLE
Rename "Products carousel" section to "Products"

### DIFF
--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -154,8 +154,8 @@
 
 {% schema %}
   {
-    "name": "Products carousel",
-    "description": "Show individual products or products from a collection in a sliding carousel",
+    "name": "Products",
+    "description": "Display individual products or items from a collection in a grid or sliding carousel",
     "tag": "section",
     "class": "products",
     "settings": [


### PR DESCRIPTION
Now that the carousel layout is optional, we should rename the section and its description.

Changelog:

1. Changed section name
2. Changed section description