### PR TITLE
Control "Powered by Booqable" with `show_powered_by` global attribute

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -177,21 +177,24 @@
       {{- footer_menu -}}
 
     </div>
-
-    <div class="footer__bottom{% if bottom_text == blank and footer_bottom_menu == blank and show_powered_by %} footer__bottom--copyright-hidden{%- endif -%}">
+    <div class="footer__bottom{% if bottom_text == blank and footer_bottom_menu == blank and show_powered_by == false %} footer__bottom--copyright-hidden{%- endif -%}">
       {%- if bottom_text != blank or footer_bottom_menu != blank or show_powered_by -%}
         <div class="footer__copy">
-          <p>
-            {%- if bottom_text != blank -%}
-              {{ bottom_text }}
-              {% if show_powered_by %}
+          {%- if bottom_text != blank or show_powered_by -%}
+            <p>
+              {%- if bottom_text != blank -%}
+                {{ bottom_text }}
+              {%- endif -%}
+
+              {%- if bottom_text != blank and show_powered_by -%}
                 &nbsp;|&nbsp;
-              {% endif %}
-            {%- endif -%}
-            {% if show_powered_by %}
-              <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>
-            {% endif %}
-          </p>
+              {%- endif -%}
+
+              {%- if show_powered_by -%}
+                <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>
+              {%- endif -%}
+            </p>
+          {%- endif -%}
 
           {%- if footer_bottom_menu != blank -%}
             {{- footer_bottom_menu -}}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -178,20 +178,26 @@
 
     </div>
 
-    <div class="footer__bottom{% if bottom_text == blank and footer_bottom_menu == blank %} footer__bottom--copyright-hidden{%- endif -%}">
-      {%- unless bottom_text == blank and footer_bottom_menu == blank -%}
+    <div class="footer__bottom{% if bottom_text == blank and footer_bottom_menu == blank and show_powered_by %} footer__bottom--copyright-hidden{%- endif -%}">
+      {%- if bottom_text != blank or footer_bottom_menu != blank or show_powered_by -%}
         <div class="footer__copy">
-          {%- if bottom_text != blank -%}
-            <p>
+          <p>
+            {%- if bottom_text != blank -%}
               {{ bottom_text }}
-            </p>
-          {%- endif -%}
+              {% if show_powered_by %}
+                &nbsp;|&nbsp;
+              {% endif %}
+            {%- endif -%}
+            {% if show_powered_by %}
+              <a href="https://booqable.com/?source=Shop&campaign=Cart" target="_blank" title="Powered by Booqable Rental Software">Powered by Booqable</a>
+            {% endif %}
+          </p>
 
           {%- if footer_bottom_menu != blank -%}
             {{- footer_bottom_menu -}}
           {%- endif -%}
         </div>
-      {%- endunless -%}
+      {%- endif -%}
 
       {{- footer_icons -}}
 


### PR DESCRIPTION
Added link "Powered by Booqable" in the footer. Appearance is controlled by `show_powered_by` global attribute:

<img width="503" alt="image" src="https://github.com/booqable/tough-theme/assets/1877965/5026a3bc-0ac9-4a10-ab91-c4784a66df97">

Requires: https://github.com/saladdays-nl/booqable/pull/9071