### PR TITLE
Video doesn't play in the second "Images" section

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -93,6 +93,7 @@
   height: 8px;
   transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
   border-radius: 50%;
+  pointer-events: none;
 }
 
 .carousel__dot.hidden {

--- a/assets/carousel.js
+++ b/assets/carousel.js
@@ -14,7 +14,7 @@ class Carousel {
       timer: ".carousel__timer",
       count: ".carousel__count",
       datePicker: ".date-picker"
-    };
+    }
 
     this.classes = {
       show: "show",
@@ -30,18 +30,18 @@ class Carousel {
       light: "overlay-light",
       showDark: "show-overlay-dark",
       showLight: "show-overlay-light"
-    };
+    }
 
     this.modifiers = {
       active: "active",
       hidden: "hidden",
       show: "show",
       hide: "hide"
-    };
+    }
 
     this.data = {
       index: "data-index"
-    };
+    }
 
     this.event = {
       click: "click",
@@ -51,7 +51,7 @@ class Carousel {
       end: "touchend",
       enter: "mouseenter",
       leave: "mouseleave"
-    };
+    }
 
     this.interval;
     this.touchstart = null;
@@ -173,7 +173,7 @@ class Carousel {
           scrollToVal: valueLeft,
           size: width,
           trigger: prev
-        };
+        }
 
         valueLeft = this.slideEfect(event, options);
 
@@ -182,7 +182,7 @@ class Carousel {
           items: children,
           index: 0,
           last: this.items.length
-        };
+        }
 
         this.fadeEffect(event, options);
       }
@@ -197,7 +197,7 @@ class Carousel {
           scrollToVal: valueLeft,
           size: width,
           trigger: next
-        };
+        }
 
         valueLeft = this.slideEfect(event, options);
 
@@ -208,7 +208,7 @@ class Carousel {
           last: 1,
           nextNumber: 1,
           nextIndex: 2
-        };
+        }
 
         this.fadeEffect(event, options);
       }
@@ -452,7 +452,7 @@ class Carousel {
     const elements = {
       wrap: this.wrap,
       datePicker: this.getSiblingElement(this.block, this.selector.datePicker, this.event.next)
-    };
+    }
 
     this.items.forEach((item, itemIndex) => {
       const isLight = item.classList.contains(this.classes.light),
@@ -462,13 +462,13 @@ class Carousel {
         addClass: this.classes.showLight,
         oldClass: this.classes.showDark,
         newClass: this.classes.showLight
-      };
+      }
 
       const optionsDark = {
         addClass: this.classes.showDark,
         oldClass: this.classes.showLight,
         newClass: this.classes.showDark
-      };
+      }
 
       if (itemIndex + 1 === index) {
         if (isLight) this.setClass(elements, optionsLight);
@@ -478,7 +478,7 @@ class Carousel {
   }
 
   setClass(elements, options) {
-    const { addClass, oldClass, newClass } = options
+    const { addClass, oldClass, newClass } = options;
 
     let isOld, isNew;
 
@@ -501,7 +501,7 @@ class Carousel {
       left: left,
       top: top,
       behavior: "smooth",
-    });
+    })
   }
 
   trigger(element, eventType) {
@@ -523,20 +523,26 @@ class Carousel {
 
     let sibling;
 
-    const setSibling = () => {
-      if (direction === this.event.prev) {
+    switch (direction) {
+      case this.event.prev:
         sibling = element.previousElementSibling;
-      } else if (direction === this.event.next) {
+
+        while (sibling) {
+          if (sibling.matches(selector)) return sibling;
+          sibling = sibling.previousElementSibling;
+        }
+
+        break;
+
+      case this.event.next:
         sibling = element.nextElementSibling;
-      }
-    }
 
-    setSibling();
+        while (sibling) {
+          if (sibling.matches(selector)) return sibling;
+          sibling = sibling.nextElementSibling;
+        }
 
-    while (sibling) {
-      if (sibling.matches(selector)) return sibling;
-
-      setSibling();
+        break;
     }
   }
 

--- a/assets/header.js
+++ b/assets/header.js
@@ -19,20 +19,20 @@ class Header {
       searchInput: ".header__search-input",
       searchReset: ".header__search-reset",
       checkbox: "input[type=checkbox]"
-    };
+    }
 
     this.classes = {
       sticky: "header--sticky",
       notSticky: "header--not-sticky",
       opened: "header--menu-opened",
       filled: "filled"
-    };
+    }
 
     this.modifier = {
       scroll: "scrolled-down",
       overflow: "overflow-hidden",
       active: "active"
-    };
+    }
 
     this.cssVar = {
       height: '--header-height',
@@ -40,26 +40,26 @@ class Header {
       viewHeight: '--preview-height',
       linkHeight: '--menu-position',
       transform: '--header-transform'
-    };
+    }
 
     this.props = {
       fixed: 'fixed'
-    };
+    }
 
     this.event = {
       mouseenter: 'mouseenter',
       mouseleave: 'mouseleave'
-    };
+    }
 
     this.attr = {
       href: "href",
       class: "class",
       style: "style"
-    };
+    }
 
     this.params = {
       q: "q"
-    };
+    }
 
     this.minHeight = 180;
     this.mediaQuery = 1100;
@@ -364,7 +364,7 @@ class Header {
     this.doc.style.setProperty(
       `${key}`,
       `${val}px`
-    );
+    )
   }
 }
 

--- a/assets/images.js
+++ b/assets/images.js
@@ -1,4 +1,4 @@
-class Banner {
+class VideoYoutube {
   constructor(block) {
     this.block = block;
 
@@ -6,7 +6,7 @@ class Banner {
       vision: ".images__vision",
       video: ".images__video-id",
       player: ".images__video"
-    };
+    }
   }
 
   init() {
@@ -74,17 +74,17 @@ class Banner {
   }
 }
 
-const initBanner = (el = ".images") => {
+const initVideo = (el = ".images") => {
   const nodes = document.querySelectorAll(el);
 
   if (!nodes.length) return false;
 
   nodes.forEach(node => {
-    const init = new Banner(node);
+    const init = new VideoYoutube(node);
     init.init();
   })
 }
 
 document.addEventListener("readystatechange", (e) => {
-  if (e.target.readyState === "complete") initBanner();
+  if (e.target.readyState === "complete") initVideo();
 })

--- a/assets/main.js
+++ b/assets/main.js
@@ -9,12 +9,12 @@ class Main {
       search: "#search",
       image: ".focal-image",
       focus: "[data-focus]"
-    };
+    }
 
     this.modifier = {
       loaded: "loaded",
       resize: "resize-active"
-    };
+    }
 
     this.params = {
       out: "out",
@@ -23,23 +23,23 @@ class Main {
       footer: "footer",
       type: "message",
       section: "section"
-    };
+    }
 
     this.props = {
       behavior: "smooth",
       block: "center"
-    };
+    }
 
     this.data = {
       focalX: "data-focal-x",
       focalY: "data-focal-y",
       focus: "data-focus"
-    };
+    }
 
     this.cssVar = {
       datePickerHeight: '--date-picker-height',
       datePickerBlockHeight: '--date-picker-block-height',
-    };
+    }
 
     this.time = 500;
     this.timeScroll = 300;

--- a/assets/maps.js
+++ b/assets/maps.js
@@ -6,22 +6,22 @@ class Map {
       map: ".map",
       icon: ".map-icon__image",
       link: ".tabs__link"
-    };
+    }
 
     this.attr = {
       id: "id",
       href: "href",
       address: "data-address"
-    };
+    }
 
     this.elem = {
       div: "div"
-    };
+    }
 
     this.classes = {
       error: "map__error",
       noImage: "no-image"
-    };
+    }
 
     this.addressErrorMessage = `we can't find this address, please check it again`;
     this.linkArr = [];

--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -6,20 +6,20 @@ class Tabs {
       tab: ".tabs__trigger",
       content: ".tabs__content",
       opener: "#tabs-select-opener"
-    };
+    }
 
     this.classes = {
       tab: "tabs__trigger"
-    };
+    }
 
     this.modifiers = {
       active: "active"
-    };
+    }
 
     this.data = {
       content: "data-content",
       trigger: "data-trigger"
-    };
+    }
   }
 
   init() {
@@ -56,7 +56,7 @@ class Tabs {
       attr: this.data.trigger,
       val: attr,
       mod: this.modifiers.active
-    };
+    }
 
     this.tabsClass(options);
 
@@ -67,7 +67,7 @@ class Tabs {
       attr: this.data.content,
       val: attr,
       mod: this.modifiers.active
-    };
+    }
 
     this.tabsClass(options);
   }

--- a/assets/touch-device-notch.js
+++ b/assets/touch-device-notch.js
@@ -4,23 +4,23 @@ class TouchDevice {
 
     this.modifier = {
       touch: "touch"
-    };
+    }
 
     this.props = {
       portrait: "portrait",
       landscape: "landscape"
-    };
+    }
 
     this.cssVars = {
       areaTop: "--safe-area-top",
       areaRight: "--safe-area-right",
       areaBottom: "--safe-area-bottom",
       areaLeft: "--safe-area-left"
-    };
+    }
 
     this.data = {
       orientation: "data-orientation"
-    };
+    }
   }
 
   init() {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -16,6 +16,17 @@
     {% include 'root-styles' %}
 
     {% include 'page-metadata' %}
+
+    {%- if template == "index" -%}
+      <script>
+        // Loading the IFrame Player API code asynchronously.
+        const tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/iframe_api";
+
+        const firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+      </script>
+    {%- endif -%}
   </head>
   <body>
 
@@ -35,6 +46,10 @@
     <script src="{{ "main.js" | asset_url }}" defer></script>
     <script src="{{ "header.js" | asset_url }}" defer></script>
     <script src="{{ "carousel.js" | asset_url }}" defer></script>
+
+    {%- if template == "index" -%}
+      <script src="{{ "images.js" | asset_url }}" defer></script>
+    {%- endif -%}
 
     {{ content_for_body }}
 

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -1,11 +1,4 @@
-<script>
-  // Loading the IFrame Player API code asynchronously.
-  const tag = document.createElement('script');
-  tag.src = "https://www.youtube.com/iframe_api";
 
-  const firstScriptTag = document.getElementsByTagName('script')[0];
-  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-</script>
 
 {%- assign blocks = section.blocks -%}
 
@@ -332,8 +325,8 @@
                       {%- assign video_id   = video_drop | last | strip -%}
 
                       <div class="images__vision-wrapper images__vision-wrapper--overlay">
-                        <input id="video-{{- block.id -}}" value="{{- video_id -}}" class="images__video-id" type="hidden" name="hidden">
-                        <div id="player-{{- block.id -}}" class="images__video"></div>
+                        <input id="video-{{- section.key -}}{{- block.id -}}" value="{{- video_id -}}" class="images__video-id" type="hidden" name="hidden">
+                        <div id="player-{{- section.key -}}{{- block.id -}}" class="images__video"></div>
                       </div>
 
                     {%- elsif video_url contains "vimeo.com" -%}
@@ -444,8 +437,6 @@
     {%- endif -%}
   </div>
 {%- endif -%}
-
-<script src="{{ "images.js" | asset_url }}" defer></script>
 
 {% schema %}
   {


### PR DESCRIPTION
New issues regarding the Images section with video playback:
1. There are errors in the console if more than one `Images` section is added per page
2. When try playing the videos in both sections, the first works, but the second doesn't

Changelog:
1. Scripts that are used with videos moved to theme.liquid
2. Added section `id` to elements that are used by Youtube video API

Before:
![Google Chrome_2023-10-10 09-40-18@2x](https://github.com/booqable/tough-theme/assets/40244261/d4e522f2-9904-41fd-85d8-f128c01237bd)
![Google Chrome_2023-10-10 09-46-50@2x](https://github.com/booqable/tough-theme/assets/40244261/245e4312-666e-42b1-af1e-a94fffae68a1)

After: 
![Google Chrome_2023-10-10 13-35-13@2x](https://github.com/booqable/tough-theme/assets/40244261/4caf9f41-e920-4fc5-bbc1-3f21f06453e2)
