### PR TITLE
Added date picker modal to layout, added default colors

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -562,9 +562,9 @@ img {
   box-shadow: 0 0 0 3px var(--color-outline, #F4B841);
 }
 
-.tippy-box *,
-.bq-modal * {
-  border-radius: var(--border-radius, 0) !important;
+.tippy-box *:not(label),
+.bq-modal *:not(label) {
+  border-radius: 0 !important;
 }
 
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -174,7 +174,8 @@
       {
         "type": "color",
         "id": "background_3",
-        "label": "Background"
+        "label": "Background",
+        "info": "Also used as the background color of 'Apply' button of Date picker modal window"
       },
       {
         "type": "color",

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -31,15 +31,15 @@
   <body>
 
     <header class="header" id="header">
-      {% section 'top-bar' %}
-      {% section 'header' %}
+      {%- section 'top-bar' -%}
+      {%- section 'header' -%}
     </header>
 
     <main id="main">
       {{ content_for_layout }}
     </main>
 
-    {% section 'footer' %}
+    {%- section 'footer' -%}
 
     <script src="{{ "lazysizes.min.js" | asset_url }}" defer></script>
     <script src="{{ "touch-device-notch.js" | asset_url }}" defer></script>
@@ -50,6 +50,14 @@
     {%- if template == "index" -%}
       <script src="{{ "images.js" | asset_url }}" defer></script>
     {%- endif -%}
+
+    {%- if settings.background_3 != blank -%}
+      {%- assign background_accent = settings.background_3 -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
+
+    <bq-date-picker-modal branding-color="{{- background_accent -}}"></bq-date-picker-modal>
 
     {{ content_for_body }}
 

--- a/sections/hero-product.liquid
+++ b/sections/hero-product.liquid
@@ -10,9 +10,17 @@
 
 {%- if show_datepicker -%}
   {%- if color_palette == "one" -%}
-    {%- assign background_accent = settings.accent_background -%}
+    {%- if settings.accent_background != blank -%}
+      {%- assign background_accent = settings.accent_background -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- elsif color_palette == "two" -%}
-    {%- assign background_accent = settings.accent_background_2 -%}
+    {%- if settings.accent_background_2 != blank -%}
+      {%- assign background_accent = settings.accent_background_2 -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- endif -%}
 {%- endif -%}
 

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -16,9 +16,17 @@
   {%- assign show_datepicker = true -%}
 
   {%- if color_palette == "one" -%}
-    {%- assign background_accent = settings.accent_background -%}
+    {%- if settings.accent_background != blank -%}
+      {%- assign background_accent = settings.accent_background -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- elsif color_palette == "two" -%}
-    {%- assign background_accent = settings.accent_background_2 -%}
+    {%- if settings.accent_background_2 != blank -%}
+      {%- assign background_accent = settings.accent_background_2 -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- endif -%}
 {%- endif -%}
 

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -13,9 +13,17 @@
 
 {%- if show_datepicker -%}
   {%- if color_palette == "one" -%}
-    {%- assign background_accent = settings.accent_background -%}
+    {%- if settings.accent_background != blank -%}
+      {%- assign background_accent = settings.accent_background -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- elsif color_palette == "two" -%}
-    {%- assign background_accent = settings.accent_background_2 -%}
+    {%- if settings.accent_background_2 != blank -%}
+      {%- assign background_accent = settings.accent_background_2 -%}
+    {%- else -%}
+      {%- assign background_accent = branding_color -%}
+    {%- endif -%}
   {%- endif -%}
 {%- endif -%}
 

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -27,9 +27,17 @@
 
   {%- if show_datepicker -%}
     {%- if color_palette == "one" -%}
-      {%- assign background_accent = settings.accent_background -%}
+      {%- if settings.accent_background != blank -%}
+        {%- assign background_accent = settings.accent_background -%}
+      {%- else -%}
+        {%- assign background_accent = branding_color -%}
+      {%- endif -%}
     {%- elsif color_palette == "two" -%}
-      {%- assign background_accent = settings.accent_background_2 -%}
+      {%- if settings.accent_background_2 != blank -%}
+        {%- assign background_accent = settings.accent_background_2 -%}
+      {%- else -%}
+        {%- assign background_accent = branding_color -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endif -%}
 

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -8,52 +8,77 @@
     --date-picker-title-line-height: 1.5;
     --date-picker-text-line-height: 1.5;
 
-    {%- if color_palette == "one" -%}
-      {%- if settings.background != blank -%}
-        --date-picker-background-color: var(--background-primary, #FFFFFF);
-      {%- endif -%}
+    {% if color_palette == "one" %}
+      {% if settings.background != blank %}
+        --date-picker-background-color: var(--background-primary);
+      {% else %}
+        --date-picker-background-color: #FFFFFF;
+      {% endif %}
 
-      {%- if settings.primary_color != blank -%}
-        --date-picker-text-color: var(--color-primary, #0B1A26);
-        --date-picker-placeholder-color: var(--color-placeholder, #0B1A2659);
-        --date-picker-section-border: 1px solid var(--color-border, #0B1A2626);
-      {%- endif -%}
+      {% if settings.primary_color != blank %}
+        --date-picker-text-color: var(--color-primary);
+        --date-picker-placeholder-color: var(--color-placeholder);
+        --date-picker-section-border: 1px solid var(--color-border);
+      {% else %}
+        --date-picker-text-color: #0B1A26;
+        --date-picker-placeholder-color: #0B1A2659;
+        --date-picker-section-border: 1px solid #0B1A2626;
+      {% endif %}
 
-      {%- if settings.accent_background != blank -%}
-        --date-picker-cleanstate-background-color: var(--background-accent, #F4B841);
-        --date-picker-box-shadow: 0 0 0 1px var(--background-accent, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background != blank %}
+        --date-picker-cleanstate-background-color: var(--background-accent);
+        --date-picker-box-shadow: 0 0 0 1px var(--background-accent);
+      {% else %}
+        --date-picker-cleanstate-background-color: #F4B841;
+        --date-picker-box-shadow: 0 0 0 1px #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color != blank -%}
-        --date-picker-icon-color: var(--color-accent, #0B1A26);
-        --date-picker-cleanstate-text-color: var(--color-accent, #0B1A26);
-        --color-accent-foreground: var(--color-accent, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color != blank %}
+        --date-picker-icon-color: var(--color-accent);
+        --date-picker-cleanstate-text-color: var(--color-accent);
+        --color-accent-foreground: var(--color-accent);
+      {% else %}
+        --date-picker-icon-color: #0B1A26;
+        --date-picker-cleanstate-text-color: #0B1A26;
+        --color-accent-foreground: #0B1A26;
+      {% endif %}
 
-    {%- elsif color_palette == "two" -%}
-      {%- if settings.background_2 != blank -%}
-        --date-picker-background-color: var(--background-primary-2, #0B1A26);
-      {%- endif -%}
+    {% elsif color_palette == "two" %}
+      {% if settings.background_2 != blank %}
+        --date-picker-background-color: var(--background-primary-2);
+      {% else %}
+        --date-picker-background-color: #0B1A26;
+      {% endif %}
 
-      {%- if settings.primary_color_2 != blank -%}
-        --date-picker-text-color: var(--color-primary-2, #FFFFFF);
-        --date-picker-placeholder-color: var(--color-placeholder-2, #FFFFFF59);
-        --date-picker-section-border: 1px solid var(--color-border-2, #FFFFFF47);
-      {%- endif -%}
+      {% if settings.primary_color_2 != blank %}
+        --date-picker-text-color: var(--color-primary-2);
+        --date-picker-placeholder-color: var(--color-placeholder-2);
+        --date-picker-section-border: 1px solid var(--color-border-2);
+      {% else %}
+        --date-picker-text-color: #FFFFFF;
+        --date-picker-placeholder-color: #FFFFFF59;
+        --date-picker-section-border: 1px solid #FFFFFF47;
+      {% endif %}
 
-      {%- if settings.accent_background_2 != blank -%}
-        --date-picker-cleanstate-background-color: var(--background-accent-2, #F4B841);
-        --date-picker-box-shadow: 0 0 0 1px var(--background-accent-2, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background_2 != blank %}
+        --date-picker-cleanstate-background-color: var(--background-accent-2);
+        --date-picker-box-shadow: 0 0 0 1px var(--background-accent-2);
+      {% else %}
+        --date-picker-cleanstate-background-color: #F4B841;
+        --date-picker-box-shadow: 0 0 0 1px #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color_2 != blank -%}
-        --date-picker-icon-color: var(--color-accent-2, #0B1A26);
-        --date-picker-cleanstate-text-color: var(--color-accent-2, #0B1A26);
-        --color-accent-foreground: var(--color-accent-2, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color_2 != blank %}
+        --date-picker-icon-color: var(--color-accent-2);
+        --date-picker-cleanstate-text-color: var(--color-accent-2);
+        --color-accent-foreground: var(--color-accent-2);
+      {% else %}
+        --date-picker-icon-color: #0B1A26;
+        --date-picker-cleanstate-text-color: #0B1A26;
+        --color-accent-foreground: #0B1A26;
+      {% endif %}
     {%- endif -%}
   }
 {%- endstyle -%}
 
-<bq-date-picker></bq-date-picker>
-<bq-date-picker-modal branding-color="{{- background_accent -}}"></bq-date-picker-modal>
+<bq-date-picker branding-color="{{- background_accent -}}"></bq-date-picker>

--- a/snippets/variables-cart-lines.liquid
+++ b/snippets/variables-cart-lines.liquid
@@ -19,53 +19,85 @@
 
     {% if color_palette == "one" %}
       {% if settings.primary_color != blank %}
-        --line-title-color: var(--color-primary, #0B1A26);
-        --line-price-color: var(--color-primary, #0B1A26);
-        --line-input-color: var(--color-primary, #0B1A26);
-        --line-bundle-item-quantity-color: var(--color-primary, #0B1A26);
-        --line-bundle-item-name-color: var(--color-primary, #0B1A26);
-        --line-border: 1px solid var(--color-border, #0B1A2626);
-        --line-image-border: 1px solid var(--color-border, #0B1A2626);
-        --line-control-border: 1px solid var(--color-border, #0B1A2626);
-        --line-variations-color: var(--color-third, #0B1A2666);
+        --line-title-color: var(--color-primary);
+        --line-price-color: var(--color-primary);
+        --line-input-color: var(--color-primary);
+        --line-bundle-item-quantity-color: var(--color-primary);
+        --line-bundle-item-name-color: var(--color-primary);
+        --line-border: 1px solid var(--color-border);
+        --line-image-border: 1px solid var(--color-border);
+        --line-control-border: 1px solid var(--color-border);
+        --line-variations-color: var(--color-third);
+      {% else %}
+        --line-title-color: #0B1A26;
+        --line-price-color: #0B1A26;
+        --line-input-color: #0B1A26;
+        --line-bundle-item-quantity-color: #0B1A26;
+        --line-bundle-item-name-color: #0B1A26;
+        --line-border: 1px solid #0B1A2626;
+        --line-image-border: 1px solid #0B1A2626;
+        --line-control-border: 1px solid #0B1A2626;
+        --line-variations-color: #0B1A2666;
       {% endif %}
 
       {% if settings.background != blank %}
-        --line-bundle-item-quantity-background: var(--background-primary, #FFFFFF);
+        --line-bundle-item-quantity-background: var(--background-primary);
+      {% else %}
+        --line-bundle-item-quantity-background: #FFFFFF;
       {% endif %}
 
       {% if settings.accent_background != blank %}
-        --line-toggle-color: var(--background-accent, #F4B841);
+        --line-toggle-color: var(--background-accent);
+      {% else %}
+        --line-toggle-color: #F4B841;
       {% endif %}
 
       {% if settings.accent_outline != blank %}
-        --line-icon-color: var(--color-outline, #F4B841);
+        --line-icon-color: var(--color-outline);
+      {% else %}
+        --line-icon-color: #F4B841;
       {% endif %}
 
     {% elsif color_palette == "two" %}
       {% if settings.primary_color_2 != blank %}
-        --line-title-color: var(--color-primary-2, #FFFFFF);
-        --line-price-color: var(--color-primary-2, #FFFFFF);
-        --line-input-color: var(--color-primary-2, #FFFFFF);
-        --line-bundle-item-quantity-color: var(--color-primary-2, #FFFFFF);
-        --line-bundle-item-name-color: var(--color-primary-2, #FFFFFF);
-        --line-border: 1px solid var(--color-border-2, #FFFFFF47);
-        --line-image-border: 1px solid var(--color-border-2, #FFFFFF47);
-        --line-control-border: 1px solid var(--color-border-2, #FFFFFF47);
-        --line-variations-color: var(--color-third-2, #FFFFFF66);
+        --line-title-color: var(--color-primary-2);
+        --line-price-color: var(--color-primary-2);
+        --line-input-color: var(--color-primary-2);
+        --line-bundle-item-quantity-color: var(--color-primary-2);
+        --line-bundle-item-name-color: var(--color-primary-2);
+        --line-border: 1px solid var(--color-border-2);
+        --line-image-border: 1px solid var(--color-border-2);
+        --line-control-border: 1px solid var(--color-border-2);
+        --line-variations-color: var(--color-third-2);
+      {% else %}
+        --line-title-color: #FFFFFF;
+        --line-price-color: #FFFFFF;
+        --line-input-color: #FFFFFF;
+        --line-bundle-item-quantity-color: #FFFFFF;
+        --line-bundle-item-name-color: #FFFFFF;
+        --line-border: 1px solid #FFFFFF47;
+        --line-image-border: 1px solid #FFFFFF47;
+        --line-control-border: 1px solid #FFFFFF47;
+        --line-variations-color: #FFFFFF66;
       {% endif %}
 
       {% if settings.background_2 != blank %}
-        --line-bundle-item-quantity-background: var(--background-primary-2, #0B1A26);
+        --line-bundle-item-quantity-background: var(--background-primary-2);
+      {% else %}
+        --line-bundle-item-quantity-background: #0B1A26;
       {% endif %}
 
       {% if settings.accent_background_2 != blank %}
-        --line-toggle-color: var(--background-accent-2, #F4B841);
+        --line-toggle-color: var(--background-accent-2);
+      {% else %}
+        --line-toggle-color: #F4B841;
       {% endif %}
 
       {% if settings.accent_outline_2 != blank %}
-        --line-icon-color: var(--color-outline-2, #F4B841);
+        --line-icon-color: var(--color-outline-2);
+      {% else %}
+        --line-icon-color: #F4B841;
       {% endif %}
-    {% endif %}
+    {%- endif -%}
   }
 {% endstyle %}

--- a/snippets/variables-cart-services.liquid
+++ b/snippets/variables-cart-services.liquid
@@ -13,37 +13,53 @@
 
     {% if color_palette == "one" %}
       {% if settings.primary_color != blank %}
-        --service-checkbox-border: 1px solid var(--color-border, #0B1A2626);
+        --service-checkbox-border: 1px solid var(--color-border);
+      {% else %}
+        --service-checkbox-border: 1px solid #0B1A2626;
       {% endif %}
 
       {% if settings.background != blank %}
-        --service-checkbox-color: var(--background-primary, #FFFFFF);
+        --service-checkbox-color: var(--background-primary);
+      {% else %}
+        --service-checkbox-color: #FFFFFF;
       {% endif %}
 
       {% if settings.accent_background != blank %}
-        --service-checkbox-color-checked: var(--background-accent, #F4B841);
+        --service-checkbox-color-checked: var(--background-accent);
+      {% else %}
+        --service-checkbox-color-checked: #F4B841;
       {% endif %}
 
       {% if settings.accent_color != blank %}
-        --service-checkbox-icon-color: var(--color-accent, #0B1A26);
+        --service-checkbox-icon-color: var(--color-accent);
+      {% else %}
+        --service-checkbox-icon-color: #0B1A26;
       {% endif %}
 
     {% elsif color_palette == "two" %}
       {% if settings.primary_color_2 != blank %}
-        --service-checkbox-border: 1px solid var(--color-border-2, #FFFFFF47);
+        --service-checkbox-border: 1px solid var(--color-border-2);
+      {% else %}
+        --service-checkbox-border: 1px solid #FFFFFF47;
       {% endif %}
 
       {% if settings.background_2 != blank %}
-        --service-checkbox-color: var(--background-primary-2, #0B1A26);
+        --service-checkbox-color: var(--background-primary-2);
+      {% else %}
+        --service-checkbox-color: #0B1A26;
       {% endif %}
 
       {% if settings.accent_background_2 != blank %}
-        --service-checkbox-color-checked: var(--background-accent-2, #F4B841);
+        --service-checkbox-color-checked: var(--background-accent-2);
+      {% else %}
+        --service-checkbox-color-checked: #F4B841;
       {% endif %}
 
       {% if settings.accent_color_2 != blank %}
-        --service-checkbox-icon-color: var(--color-accent-2, #0B1A26);
+        --service-checkbox-icon-color: var(--color-accent-2);
+      {% else %}
+        --service-checkbox-icon-color: #0B1A26;
       {% endif %}
-    {% endif %}
+    {%- endif -%}
   }
 {% endstyle %}

--- a/snippets/variables-cart-totals.liquid
+++ b/snippets/variables-cart-totals.liquid
@@ -19,44 +19,66 @@
     --totals-error-font-size: 16px;
     --totals-error-font-weight: 400;
 
-    {%- if color_palette == "one" -%}
+    {% if color_palette == "one" %}
       {% if settings.primary_color != blank %}
-        --secondary-button-button-label-color: var(--color-primary, #0B1A26);
-        --totals-text-color: var(--color-primary, #0B1A26);
-        --totals-border: 1px solid var(--color-border, #0B1A2626);
+        --secondary-button-button-label-color: var(--color-primary);
+        --totals-text-color: var(--color-primary);
+        --totals-border: 1px solid var(--color-border);
+      {% else %}
+        --secondary-button-button-label-color: #0B1A26;
+        --totals-text-color: #0B1A26;
+        --totals-border: 1px solid #0B1A2626;
       {% endif %}
 
       {% if settings.background != blank %}
-        --secondary-button-button-color: var(--background-primary, #FFFFFF);
+        --secondary-button-button-color: var(--background-primary);
+      {% else %}
+        --secondary-button-button-color: #FFFFFF;
       {% endif %}
 
       {% if settings.accent_background != blank %}
-        --book-button-button-color: var(--background-accent, #F4B841);
-        --secondary-button-button-border: 1px solid var(--background-accent, #F4B841);
+        --book-button-button-color: var(--background-accent);
+        --secondary-button-button-border: 1px solid var(--background-accent);
+      {% else %}
+        --book-button-button-color: #F4B841;
+        --secondary-button-button-border: 1px solid #F4B841;
       {% endif %}
 
       {% if settings.accent_color != blank %}
-        --book-button-button-label-color: var(--color-accent, #0B1A26);
+        --book-button-button-label-color: var(--color-accent);
+      {% else %}
+        --book-button-button-label-color: #0B1A26;
       {% endif %}
 
-    {%- elsif color_palette == "two" -%}
+    {% elsif color_palette == "two" %}
       {% if settings.primary_color_2 != blank %}
-        --secondary-button-button-label-color: var(--color-primary-2, #FFFFFF);
-        --totals-text-color: var(--color-primary-2, #FFFFFF);
-        --totals-border: 1px solid var(--color-border-2, #FFFFFF47);
+        --secondary-button-button-label-color: var(--color-primary-2);
+        --totals-text-color: var(--color-primary-2);
+        --totals-border: 1px solid var(--color-border-2);
+      {% else %}
+        --secondary-button-button-label-color: #FFFFFF;
+        --totals-text-color: #FFFFFF;
+        --totals-border: 1px solid #FFFFFF47;
       {% endif %}
 
       {% if settings.background_2 != blank %}
-        --secondary-button-button-color: var(--background-primary-2, #0B1A26);
+        --secondary-button-button-color: var(--background-primary-2);
+      {% else %}
+        --secondary-button-button-color: #0B1A26;
       {% endif %}
 
       {% if settings.accent_background_2 != blank %}
-        --book-button-button-color: var(--background-accent-2, #F4B841);
-        --secondary-button-button-border: 1px solid var(--background-accent-2, #F4B841);
+        --book-button-button-color: var(--background-accent-2);
+        --secondary-button-button-border: 1px solid var(--background-accent-2);
+      {% else %}
+        --book-button-button-color: #F4B841;
+        --secondary-button-button-border: 1px solid #F4B841;
       {% endif %}
 
       {% if settings.accent_color_2 != blank %}
-        --book-button-button-label-color: var(--color-accent-2, #0B1A26);
+        --book-button-button-label-color: var(--color-accent-2);
+      {% else %}
+        --book-button-button-label-color: #0B1A26;
       {% endif %}
     {%- endif -%}
   }

--- a/snippets/variables-mini-cart.liquid
+++ b/snippets/variables-mini-cart.liquid
@@ -9,39 +9,55 @@
     --minicart-button-transition-duration: var(--animation-duration, 200ms);
     --minicart-button-font: var(--font-body, --minicart-font, sans-serif);
 
-    {%- if color_palette == "one" -%}
-      {%- if settings.primary_color != blank -%}
-        --minicart-button-color: var(--color-primary, #0B1A26);
-      {%- endif -%}
+    {% if color_palette == "one" %}
+      {% if settings.primary_color != blank %}
+        --minicart-button-color: var(--color-primary);
+      {% else %}
+        --minicart-button-color: #0B1A26;
+      {% endif %}
 
-      {%- if settings.accent_background != blank -%}
-        --minicart-button-accent-color: var(--background-accent, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background != blank %}
+        --minicart-button-accent-color: var(--background-accent);
+      {% else %}
+        --minicart-button-accent-color: #F4B841;
+      {% endif %}
 
       {% if settings.accent_color != blank %}
-        --minicart-button-badge-color: var(--color-accent, #0B1A26);
+        --minicart-button-badge-color: var(--color-accent);
+      {% else %}
+        --minicart-button-badge-color: #0B1A26;
       {% endif %}
 
-      {%- if settings.accent_outline != blank -%}
-        --minicart-button-hover-color: var(--color-outline-hover, #F4B841CC);
-      {%- endif -%}
+      {% if settings.accent_outline != blank %}
+        --minicart-button-hover-color: var(--color-outline-hover);
+      {% else %}
+        --minicart-button-hover-color: #F4B841CC;
+      {% endif %}
 
-    {%- elsif color_palette == "two" -%}
-      {%- if settings.primary_color_2 != blank -%}
-        --minicart-button-color: var(--color-primary-2, #FFFFFF);
-      {%- endif -%}
+    {% elsif color_palette == "two" %}
+      {% if settings.primary_color_2 != blank %}
+        --minicart-button-color: var(--color-primary-2);
+      {% else %}
+        --minicart-button-color: #FFFFFF;
+      {% endif %}
 
-      {%- if settings.accent_background_2 != blank -%}
-        --minicart-button-accent-color: var(--background-accent-2, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background_2 != blank %}
+        --minicart-button-accent-color: var(--background-accent-2);
+      {% else %}
+        --minicart-button-accent-color: #F4B841;
+      {% endif %}
 
       {% if settings.accent_color_2 != blank %}
-        --minicart-button-badge-color: var(--color-accent-2, #FFFFFF);
+        --minicart-button-badge-color: var(--color-accent-2);
+      {% else %}
+        --minicart-button-badge-color: #FFFFFF;
       {% endif %}
 
-      {%- if settings.accent_outline_2 != blank -%}
-        --minicart-button-hover-color: var(--color-outline-2-hover, #F4B841CC);
-      {%- endif -%}
+      {% if settings.accent_outline_2 != blank %}
+        --minicart-button-hover-color: var(--color-outline-2-hover);
+      {% else %}
+        --minicart-button-hover-color: #F4B841CC;
+      {% endif %}
     {%- endif -%}
   }
 {% endstyle %}

--- a/snippets/variables-product-gallery.liquid
+++ b/snippets/variables-product-gallery.liquid
@@ -13,35 +13,51 @@
     --product-gallery-thumbnail-border-radius: var(--border-radius, 0);
     --product-gallery-thumbnail-size: var(--thumbnail-size, 80px);
 
-    {%- if color_palette == "one" -%}
-      {%- if settings.primary_color != blank -%}
-        --product-gallery-preview-border: 1px solid var(--color-border, #0B1A2626);
-        --product-gallery-thumbnail-border: 1px solid var(--color-border, #0B1A2626);
-      {%- endif -%}
+    {% if color_palette == "one" %}
+      {% if settings.primary_color != blank %}
+        --product-gallery-preview-border: 1px solid var(--color-border);
+        --product-gallery-thumbnail-border: 1px solid var(--color-border);
+      {% else %}
+        --product-gallery-preview-border: 1px solid #0B1A2626;
+        --product-gallery-thumbnail-border: 1px solid #0B1A2626;
+      {% endif %}
 
-      {%- if settings.accent_background != blank -%}
-        --product-gallery-control-background-color: var(--background-accent, #F4B841);
-        --product-gallery-active-thumbnail-border: 1px solid var(--background-accent, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background != blank %}
+        --product-gallery-control-background-color: var(--background-accent);
+        --product-gallery-active-thumbnail-border: 1px solid var(--background-accent);
+      {% else %}
+        --product-gallery-control-background-color: #F4B841;
+        --product-gallery-active-thumbnail-border: 1px solid #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color != blank -%}
-        --product-gallery-control-icon-color: var(--color-accent, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color != blank %}
+        --product-gallery-control-icon-color: var(--color-accent);
+      {% else %}
+        --product-gallery-control-icon-color: #0B1A26;
+      {% endif %}
 
-    {%- elsif color_palette == "two" -%}
-      {%- if settings.primary_color_2 != blank -%}
-        --product-gallery-preview-border: 1px solid var(--color-border-2, #FFFFFF47);
-        --product-gallery-thumbnail-border: 1px solid var(--color-border-2, #FFFFFF47);
-      {%- endif -%}
+    {% elsif color_palette == "two" %}
+      {% if settings.primary_color_2 != blank %}
+        --product-gallery-preview-border: 1px solid var(--color-border-2);
+        --product-gallery-thumbnail-border: 1px solid var(--color-border-2);
+      {% else %}
+        --product-gallery-preview-border: 1px solid #FFFFFF47;
+        --product-gallery-thumbnail-border: 1px solid #FFFFFF47;
+      {% endif %}
 
-      {%- if settings.accent_background_2 != blank -%}
-        --product-gallery-control-background-color: var(--background-accent-2, #F4B841);
-        --product-gallery-active-thumbnail-border: 1px solid var(--background-accent-2, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background_2 != blank %}
+        --product-gallery-control-background-color: var(--background-accent-2);
+        --product-gallery-active-thumbnail-border: 1px solid var(--background-accent-2);
+      {% else %}
+        --product-gallery-control-background-color: #F4B841;
+        --product-gallery-active-thumbnail-border: 1px solid #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color_2 != blank -%}
-        --product-gallery-control-icon-color: var(--color-accent-2, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color_2 != blank %}
+        --product-gallery-control-icon-color: var(--color-accent-2);
+      {% else %}
+        --product-gallery-control-icon-color: #0B1A26;
+      {% endif %}
     {%- endif -%}
   }
 {% endstyle %}

--- a/snippets/variables-product-quantity.liquid
+++ b/snippets/variables-product-quantity.liquid
@@ -11,43 +11,63 @@
     --add-button-input-width: 110px;
     --add-button-label-weight: 700;
 
-    {%- if color_palette == "one" -%}
-      {%- if settings.background != blank -%}
-        --add-button-input-background-color: var(--background-primary, #FFFFFF);
-      {%- endif -%}
+    {% if color_palette == "one" %}
+      {% if settings.background != blank %}
+        --add-button-input-background-color: var(--background-primary);
+      {% else %}
+        --add-button-input-background-color: #FFFFFF;
+      {% endif %}
 
-      {%- if settings.primary_color != blank -%}
-        --add-button-input-color: var(--color-primary, #0B1A26);
-        --add-button-control-button-color: var(--color-primary, #0B1A26);
-        --add-button-input-border: 1px solid var(--color-border, #0B1A2626);
-      {%- endif -%}
+      {% if settings.primary_color != blank %}
+        --add-button-input-color: var(--color-primary);
+        --add-button-control-button-color: var(--color-primary);
+        --add-button-input-border: 1px solid var(--color-border);
+      {% else %}
+        --add-button-input-color: #0B1A26;
+        --add-button-control-button-color: #0B1A26;
+        --add-button-input-border: 1px solid #0B1A2626;
+      {% endif %}
 
-      {%- if settings.accent_background != blank -%}
-        --add-button-button-color: var(--background-accent, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background != blank %}
+        --add-button-button-color: var(--background-accent);
+      {% else %}
+        --add-button-button-color: #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color != blank -%}
-        --add-button-button-label-color: var(--color-accent, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color != blank %}
+        --add-button-button-label-color: var(--color-accent);
+      {% else %}
+        --add-button-button-label-color: #0B1A26;
+      {% endif %}
 
-    {%- elsif color_palette == "two" -%}
-      {%- if settings.background_2 != blank -%}
-        --add-button-input-background-color: var(--background-primary-2, #0B1A26);
-      {%- endif -%}
+    {% elsif color_palette == "two" %}
+      {% if settings.background_2 != blank %}
+        --add-button-input-background-color: var(--background-primary-2);
+      {% else %}
+        --add-button-input-background-color: #0B1A26;
+      {% endif %}
 
-      {%- if settings.primary_color_2 != blank -%}
-        --add-button-input-color: var(--color-primary-2, #FFFFFF);
-        --add-button-control-button-color: var(--color-primary-2, #FFFFFF);
-        --add-button-input-border: 1px solid var(--color-border-2, #FFFFFF47);
-      {%- endif -%}
+      {% if settings.primary_color_2 != blank %}
+        --add-button-input-color: var(--color-primary-2);
+        --add-button-control-button-color: var(--color-primary-2);
+        --add-button-input-border: 1px solid var(--color-border-2);
+      {% else %}
+        --add-button-input-color: #FFFFFF;
+        --add-button-control-button-color: #FFFFFF;
+        --add-button-input-border: 1px solid #FFFFFF47;
+      {% endif %}
 
-      {%- if settings.accent_background_2 != blank -%}
-        --add-button-button-color: var(--background-accent-2, #F4B841);
-      {%- endif -%}
+      {% if settings.accent_background_2 != blank %}
+        --add-button-button-color: var(--background-accent-2);
+      {% else %}
+        --add-button-button-color: #F4B841;
+      {% endif %}
 
-      {%- if settings.accent_color_2 != blank -%}
-        --add-button-button-label-color: var(--color-accent-2, #0B1A26);
-      {%- endif -%}
+      {% if settings.accent_color_2 != blank %}
+        --add-button-button-label-color: var(--color-accent-2);
+      {% else %}
+        --add-button-button-label-color: #0B1A26;
+      {% endif %}
     {%- endif -%}
   }
 {%- endstyle -%}

--- a/snippets/variables-product-variations.liquid
+++ b/snippets/variables-product-variations.liquid
@@ -10,31 +10,47 @@
     --bundle-items-cell-padding: 5px;
     --bundle-items-font-size: 15px;
 
-    {%- if color_palette == "one" -%}
-      {%- if settings.background != blank -%}
-        --variation-select-background-color: var(--background-primary, #FFFFFF);
-        --bundle-items-background-color: var(--background-primary, #FFFFFF);
-      {%- endif -%}
+    {% if color_palette == "one" %}
+      {% if settings.background != blank %}
+        --variation-select-background-color: var(--background-primary);
+        --bundle-items-background-color: var(--background-primary);
+      {% else %}
+        --variation-select-background-color: #FFFFFF;
+        --bundle-items-background-color: #FFFFFF;
+      {% endif %}
 
-      {%- if settings.primary_color != blank -%}
-        --variation-select-color: var(--color-primary, #0B1A26);
-        --variation-select-border: 1px solid var(--color-border, #0B1A2626);
-        --bundle-items-color: var(--color-primary, #0B1A26);
-        --bundle-items-image-border: 1px solid var(--color-border, #0B1A2626);
-      {%- endif -%}
+      {% if settings.primary_color != blank %}
+        --variation-select-color: var(--color-primary);
+        --variation-select-border: 1px solid var(--color-border);
+        --bundle-items-color: var(--color-primary);
+        --bundle-items-image-border: 1px solid var(--color-border);
+      {% else %}
+        --variation-select-color: #0B1A26;
+        --variation-select-border: 1px solid #0B1A2626;
+        --bundle-items-color: #0B1A26;
+        --bundle-items-image-border: 1px solid #0B1A2626;
+      {% endif %}
 
-    {%- elsif color_palette == "two" -%}
-      {%- if settings.background_2 != blank -%}
-        --variation-select-background-color: var(--background-primary-2, #0B1A26);
-        --bundle-items-background-color: var(--background-primary-2, #0B1A26);
-      {%- endif -%}
+    {% elsif color_palette == "two" %}
+      {% if settings.background_2 != blank %}
+        --variation-select-background-color: var(--background-primary-2);
+        --bundle-items-background-color: var(--background-primary-2);
+      {% else %}
+        --variation-select-background-color: #0B1A26;
+        --bundle-items-background-color: #0B1A26;
+      {% endif %}
 
-      {%- if settings.primary_color_2 != blank -%}
-        --variation-select-color: var(--color-primary-2, #FFFFFF);
-        --variation-select-border: 1px solid var(--color-border-2, #FFFFFF47);
-        --bundle-items-color: var(--color-primary-2, #FFFFFF);
-        --bundle-items-image-border: 1px solid var(--color-border-2, #FFFFFF47);
-      {%- endif -%}
+      {% if settings.primary_color_2 != blank %}
+        --variation-select-color: var(--color-primary-2);
+        --variation-select-border: 1px solid var(--color-border-2);
+        --bundle-items-color: var(--color-primary-2);
+        --bundle-items-image-border: 1px solid var(--color-border-2);
+      {% else %}
+        --variation-select-color: #FFFFFF;
+        --variation-select-border: 1px solid #FFFFFF47;
+        --bundle-items-color: #FFFFFF;
+        --bundle-items-image-border: 1px solid #FFFFFF47;
+      {% endif %}
     {%- endif -%}
   }
 {%- endstyle -%}


### PR DESCRIPTION
Added `date-picker-modal ` component to the layout. It was done to resolve the issue if `Add to cart` button behavior is set to `Checkout`, so the mini cart is not shown on the page, and the `Date picker` section is also not added to the page, but during cart overdue evaluation if the dates are in past there is no picker mounted, so the dates can't be changed.
Besides that, during testing `date-picker-modal `'s colors was noticed the issue that the default (fallback) colors of all shop components didn't work at all  