### PR TITLE
Collection images are not loaded in Safari

### DIFF
--- a/assets/collections.css
+++ b/assets/collections.css
@@ -38,6 +38,10 @@
   line-height: 1.4;
 }
 
+.collections__heading a {
+  font-family: inherit;
+}
+
 .collections__link {
   display: block;
   position: relative;
@@ -224,10 +228,12 @@
     aspect-ratio: 1 / 1.48;
   }
 
+  .collections__list-2 .collections__item > .collections__image-item:after,
   .collections__list-2 .collections__link:after {
     aspect-ratio: 1 / 0.92;
   }
 
+  .collections__list-3 .collections__item > .collections__image-item:after,
   .collections__list-3 .collections__link:after {
     aspect-ratio: 1 / 1.42;
   }

--- a/assets/collections.css
+++ b/assets/collections.css
@@ -66,6 +66,7 @@
 }
 
 .collections__image-item {
+  display: block;
   position: absolute;
   top: 0;
   left: 0;

--- a/assets/rx.css
+++ b/assets/rx.css
@@ -6,13 +6,19 @@
   list-style: decimal;
 }
 
-.bq-content.rx-content {
+.bq-content.rx-content:not(h1) {
   font-family: var(--font-body, sans-serif);
   line-height: var(--line-height-lg, 1.5);
+  font-size: inherit;
 }
 
-.bq-content.rx-content:not(h1) {
-  font-size: inherit;
+:is(.bq-content.rx-content):is(h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6) {
+  font-family: var(--font-heading, sans-serif);
+  line-height: var(--line-height-sm, 1.2);
+}
+
+:is(.bq-content.rx-content):is(h4, .h4, h5, .h5, h6, .h6) {
+  line-height: var(--line-height-md, 1.3);
 }
 
 .bq-content.rx-content h1 + *,

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -170,13 +170,13 @@
     {%- endif -%}
 
     {%- if settings.heading_font != blank -%}
-      --font-heading: {{ settings.heading_font.family }}, {{ settings.heading_font.fallback_families }};
+      --font-heading: "{{ settings.heading_font.family }}", {{ settings.heading_font.fallback_families }};
     {%- endif -%}
     {%- if settings.body_font != blank -%}
-      --font-body: {{ settings.body_font.family }}, {{ settings.body_font.fallback_families }};
+      --font-body: "{{ settings.body_font.family }}", {{ settings.body_font.fallback_families }};
     {%- endif -%}
       {%- if settings.tagline_font != blank -%}
-      --font-tagline: {{ settings.tagline_font.family }}, {{ settings.tagline_font.fallback_families }};
+      --font-tagline: "{{ settings.tagline_font.family }}", {{ settings.tagline_font.fallback_families }};
     {%- endif -%}
 
     {%- if settings.h1_size != blank -%}


### PR DESCRIPTION
The first purpose of the PR is to make the collection images visible and have the same height in the `Collections` section in Safari.
The second one the fonts didn't work properly if the font name consists of 2 words with space between them then always the fallback font rendered
And added/corrected some styles of `wysiwyg` editor.