### PR TITLE
Removed unneeded styles of Logos

### DIFF
--- a/assets/logos.css
+++ b/assets/logos.css
@@ -114,9 +114,3 @@
     padding-bottom: 16px;
   }
 }
-
-@media (min-width: 1200px) {
-  .logos__col + .logos__logos {
-    padding-left: 7.2%;
-  }
-}


### PR DESCRIPTION
There was an extra `padding-left` and Logos were not centered perfectly if the title is in `center` mode on the desktop