### PR TITLE
Fix freezing website when main menu is not present

### DIFF
--- a/assets/header.js
+++ b/assets/header.js
@@ -180,7 +180,7 @@ class Header {
   menuOverflow(e) {
     const target = e?.target.previousElementSibling;
 
-    if (target !== this.menuOpener) return false;
+    if (!target || target !== this.menuOpener) return false;
 
     this.menuOpener && this.menuOpener.checked ? this.closeMenu() : this.addOverflow()
   }


### PR DESCRIPTION
The `menuOverflow` function is bound to a click event listener on the whole body.
It uses line #183 to short-circuit clicks on elements that are not intended targets.

However, when menu is not rendered (can be configured in settings), the `menuOpener` is null. If element that was clicked does not have `previousElementSibling` then `target` will also be null. This will cause `target !== this.menuOpener` to be false, the short-circuit will not be triggered and `this.addOverflow()` will be called.

This applies `overflow-hidden` CSS class to the body, which prevents web page from scrolling, making it seem like the website is frozen.

To fix this issue, we make sure that if `target` is undefined we immediately short-circuit this function.
