### PR TITLE
Added separate date picker section

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -236,6 +236,7 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
+  margin: 0;
 }
 
 .carousel__edges .carousel__dot {

--- a/assets/date-picker.css
+++ b/assets/date-picker.css
@@ -1,0 +1,99 @@
+.date-picker__wrapper {
+  width: 100%;
+}
+
+.date-picker__container--padding-top {
+  padding-top: var(--padding-top-mobile, 16px);
+}
+
+.date-picker__container--padding-bottom {
+  padding-bottom: var(--padding-bottom-mobile, 16px);
+}
+
+@keyframes move {
+  0% {
+    transform: translateY(15%) rotate(90deg);
+  }
+
+  33% {
+    transform: translateY(75%) rotate(90deg);
+  }
+
+  66% {
+    transform: translateY(-20%) rotate(90deg);
+  }
+
+  100% {
+    transform: translateY(15%) rotate(90deg);
+  }
+}
+
+.date-picker__icon {
+  margin: 0 8px 0 0;
+}
+
+.date-picker__icon svg {
+  transform: translateY(15%) rotate(90deg);
+  animation: 1.5s infinite alternate move;
+  width: 16px;
+  height: 17px;
+}
+
+.date-picker__title {
+  display: flex;
+  font-size: 18px;
+  font-weight: var(--font-weight-regular, 400);
+}
+
+.date-picker__component {
+  margin: 0 1px;
+}
+
+.palette-one.date-picker__wrapper {
+  background: var(--background-primary, #FFFFFF);
+  color: var(--color-primary, #0B1A26);
+}
+
+.palette-one .date-picker__icon path {
+  fill: var(--color-primary, #0B1A26);
+}
+
+.palette-one .date-picker__title {
+  color: var(--color-primary, #0B1A26);
+}
+
+.palette-two.date-picker__wrapper {
+  background: var(--background-primary-2, #0B1A26);
+  color: var(--color-primary-2, #FFFFFF);
+}
+
+.palette-two .date-picker__icon path {
+  fill: var(--color-primary-2, #FFFFFF);
+}
+
+.palette-two .date-picker__title {
+  color: var(--color-primary-2, #FFFFFF);
+}
+
+.palette-three.date-picker__wrapper {
+  background: var(--background-primary-3, #F4B841);
+  color: var(--color-primary-3, #0B1A26);
+}
+
+.palette-three .date-picker__icon path {
+  fill: var(--color-primary-3, #0B1A26);
+}
+
+.palette-three .date-picker__title {
+  color: var(--color-primary-3, #0B1A26);
+}
+
+@media (min-width: 992px) {
+  .date-picker__container--padding-top {
+    padding-top: var(--padding-top, 16px);
+  }
+
+  .date-picker__container--padding-bottom {
+    padding-bottom: var(--padding-bottom, 16px);
+  }
+}

--- a/assets/images.css
+++ b/assets/images.css
@@ -153,6 +153,7 @@
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 2;
 }
 
 .images__date-picker-container {

--- a/assets/rx.css
+++ b/assets/rx.css
@@ -17,6 +17,10 @@
   line-height: var(--line-height-sm, 1.2);
 }
 
+:is(.bq-content.rx-content):is(h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6) * {
+  line-height: inherit;
+}
+
 :is(.bq-content.rx-content):is(h4, .h4, h5, .h5, h6, .h6) {
   line-height: var(--line-height-md, 1.3);
 }

--- a/sections/date-picker.liquid
+++ b/sections/date-picker.liquid
@@ -1,0 +1,238 @@
+{{ "date-picker.css" | asset_url | stylesheet_tag }}
+
+{%- assign title                 = section.settings.title -%}
+{%- assign color_palette         = section.settings.color_palette -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_bottom        = section.settings.padding_bottom -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+
+{%- if color_palette == "one" -%}
+  {%- if settings.accent_background != blank -%}
+    {%- assign background_accent = settings.accent_background -%}
+  {%- else -%}
+    {%- assign background_accent = branding_color -%}
+  {%- endif -%}
+{%- elsif color_palette == "two" -%}
+  {%- if settings.accent_background_2 != blank -%}
+    {%- assign background_accent = settings.accent_background_2 -%}
+  {%- else -%}
+    {%- assign background_accent = branding_color -%}
+  {%- endif -%}
+{%- elsif color_palette == "three" -%}
+  {%- if settings.accent_background_3 != blank -%}
+    {%- assign background_accent = settings.accent_background_3 -%}
+  {%- else -%}
+    {%- assign background_accent = branding_color -%}
+  {%- endif -%}
+{%- endif -%}
+
+{% comment %} CSS variables start {% endcomment %}
+{%- capture variables -%}
+  {%- case padding_top -%}
+    {%- when 'none' -%}
+      --padding-top: 0;
+    {%- when 'small' -%}
+      --padding-top: 8px;
+    {%- when 'medium' -%}
+      --padding-top: 16px;
+    {%- when 'large' -%}
+      --padding-top: 24px;
+  {%- endcase -%}
+
+  {%- case padding_bottom -%}
+    {%- when 'none' -%}
+      --padding-bottom: 0;
+    {%- when 'small' -%}
+      --padding-bottom: 8px;
+    {%- when 'medium' -%}
+      --padding-bottom: 16px;
+    {%- when 'large' -%}
+      --padding-bottom: 24px;
+  {%- endcase -%}
+
+  {%- case padding_top_mobile -%}
+    {%- when 'none' -%}
+      --padding-top-mobile: 0;
+    {%- when 'small' -%}
+      --padding-top-mobile: 8px;
+    {%- when 'medium' -%}
+      --padding-top-mobile: 16px;
+    {%- when 'large' -%}
+      --padding-top-mobile: 24px;
+  {%- endcase -%}
+
+  {%- case padding_bottom_mobile -%}
+    {%- when 'none' -%}
+      --padding-bottom-mobile: 0;
+    {%- when 'small' -%}
+      --padding-bottom-mobile: 8px;
+    {%- when 'medium' -%}
+      --padding-bottom-mobile: 16px;
+    {%- when 'large' -%}
+      --padding-bottom-mobile: 24px;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
+
+<div class="date-picker__wrapper{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
+  <div class="date-picker__container container{% if padding_top != blank or padding_top_mobile != blank %} date-picker__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} date-picker__container--padding-bottom{%- endif -%}">
+    {%- if title != blank -%}
+      <h2 class="date-picker__title">
+        <span class="date-picker__icon">
+          {%- render 'icon-arrow-right-full' -%}
+        </span>
+        {{- title -}}
+      </h2>
+    {%- endif -%}
+
+    <div class="date-picker__component">
+      {%- include 'date-picker' -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+  {
+    "name": "Date picker",
+    "description": "Let your visitors select a rental period",
+    "tag": "section",
+    "class": "date-picker-section",
+    "settings": [
+      {
+        "type": "header",
+        "content": "General settings"
+      },
+      {
+        "type": "text",
+        "id": "title",
+        "label": "Title",
+        "default": "Check availability:"
+      },
+      {
+        "type": "select",
+        "id": "color_palette",
+        "label": "Color palette",
+        "options": [
+          {
+            "value": "one",
+            "label": "Color set 1"
+          },
+          {
+            "value": "two",
+            "label": "Color set 2"
+          },
+          {
+            "value": "three",
+            "label": "Color set 3"
+          }
+        ],
+        "default": "two"
+      },
+      {
+        "type": "header",
+        "content": "Desktop settings"
+      },
+      {
+        "type": "select",
+        "id": "padding_top",
+        "label": "Padding top",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      },
+      {
+        "type": "select",
+        "id": "padding_bottom",
+        "label": "Padding bottom",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      },
+      {
+        "type": "header",
+        "content": "Mobile settings"
+      },
+      {
+        "type": "select",
+        "id": "padding_top_mobile",
+        "label": "Padding top",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      },
+      {
+        "type": "select",
+        "id": "padding_bottom_mobile",
+        "label": "Padding bottom",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      }
+    ]
+  }
+{% endschema %}

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -1,5 +1,5 @@
 {%- style -%}
-  bq-date-picker {
+  #section-{{ section.key }} bq-date-picker {
     --date-picker-border-radius: var(--border-radius, 0);
     --date-picker-cleanstate-padding: 11px 22px;
     --date-picker-section-padding: 12px;


### PR DESCRIPTION
Although the date picker is an option for certain sections, it should also be available as a separate section for every page. At this time, the option to add the date picker is missing from the "Add section" list.

Changelog:
1. Added separate `Date picker` section
2. Carousel dots of `Images` section were centered
3. Fixed `line-height` of the `title` of `Images` section

Seems like the date picker works without any errors even if there is more than 1 copy on the page

![ezgif-1-e1dfc3a8c0](https://github.com/booqable/tough-theme/assets/40244261/6f5541f0-8f7a-4b7e-9d72-002c861594e4)
