### PR TITLE
Strip HTML before truncating to avoid not-closed tags

### DIFF
--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -49,7 +49,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description | truncate: 118, " ..." -%}
+  {%- assign excerpt = product.description |  strip_html | truncate: 118, " ..." -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 


### PR DESCRIPTION
We allow HTML in product descriptions, this caused an issue when truncating them.
Example:
`<b>This is a very long description that is bold</b>`
Would be truncated to
`<b>This is a very long...`
Which would leave us with an unclosed tag that would break the layout.

As a solution we make sure to strip HTML tags before truncating.

**Before**
![Screenshot 2023-11-09 at 09 52 57](https://github.com/booqable/tough-theme/assets/690113/dd795465-f2c9-45ca-9b2b-d21fc2ae45e4)

**After**
![Screenshot 2023-11-09 at 09 49 50](https://github.com/booqable/tough-theme/assets/690113/b4652f32-6536-4141-9517-a1ec5b4548fc)
