### PR TITLE
Fix Construct theme key

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -1,6 +1,6 @@
 {
   "variations": {
-    "default": {
+    "construct": {
       "sections": {
         "top-bar": {
           "type": "top-bar",


### PR DESCRIPTION
The "current" key was removed, however it was used as a fallback for "construct" theme as it was missing it's own key. Here we are reusing "default" as "construct".