### PR TITLE
Focus theme's Element style should be Modern by default

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -811,7 +811,7 @@
       }
     },
     "focus": {
-      "element_design": "classic",
+      "element_design": "modern",
       "background_style": "none",
       "background": "#FFFFFF",
       "background_2": "#CDEEE6",


### PR DESCRIPTION
In the current version of Focus, the Element style is set to Classic on install. It should be set to Modern. 