### PR TITLE
Fix responsive images

### DIFF
--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -33,25 +33,40 @@
   {%- assign alt = custom_alt -%}
 {%- endif -%}
 
+{% comment %}
+This code ensures we load the correct image size based on its width on the screen.
+Media queries are built relative to the viewport width, so we define image size depending on expected witdh relative to the viewport.
+
+For example:
+A hero image would be approximately as wide as the whole viewport, so we would use the xxl size.
+A testimonial image would be approximately as wide as half of the viewport (as it is show on the side), so we would use the l size.
+
+xs - Image is wide as 1/16 of the viewport
+s - Image is wide as 1/8 of the viewport
+m - Image is wide as 1/4 of the viewport
+l - Image is wide as half of the viewport
+xl - Image is wide as 3/4 of the viewport
+xxl - Image is as wide as the whole viewport
+{% endcomment %}
 {%- case size -%}
   {%- when 'xs' -%}
-    {%- assign image_width = '25, 50' -%}
-    {%- assign image_sizes = '(min-width: 320px) 25px, (min-width: 768px) 50px' -%}
+    {%- assign image_width = '20, 30, 48, 75, 105, 160' -%}
+    {%- assign image_sizes = '(max-width: 320px) 20px, (max-width: 480px) 30px, (max-width: 768px) 48px, (max-width: 1200px) 75px, (max-width: 1680px) 105px, 160px' -%}
   {%- when 's' -%}
-    {%- assign image_width = '150, 250, 400' -%}
-    {%- assign image_sizes = '(min-width: 320px) 150px, (min-width: 480px) 250px, (min-width: 768px) 400px' -%}
+    {%- assign image_width = '40, 60, 96, 150, 210, 320' -%}
+    {%- assign image_sizes = '(max-width: 320px) 40px, (max-width: 480px) 60px, (max-width: 768px) 96px, (max-width: 1200px) 150px, (max-width: 1680px) 210px, 320px' -%}
   {%- when 'm' -%}
-    {%- assign image_width = '450, 550, 650' -%}
-    {%- assign image_sizes = '(min-width: 320px) 450px, (min-width: 480px) 550px, (min-width: 768px) 650px' -%}
+    {%- assign image_width = '80, 120, 192, 300, 420, 640' -%}
+    {%- assign image_sizes = '(max-width: 320px) 80px, (max-width: 480px) 120px, (max-width: 768px) 192px, (max-width: 1200px) 300px, (max-width: 1680px) 420px, 640px' -%}
   {%- when 'l' -%}
-    {%- assign image_width = '600, 800, 1000' -%}
-    {%- assign image_sizes = '(min-width: 320px) 600px, (min-width: 576px) 800px, (min-width: 992px) 1000px' -%}
+    {%- assign image_width = '160, 240, 384, 600, 840, 1280' -%}
+    {%- assign image_sizes = '(max-width: 320px) 160px, (max-width: 480px) 240px, (max-width: 768px) 384px, (max-width: 1200px) 600px, (max-width: 1680px) 840px, 1280px' -%}
   {%- when 'xl' -%}
-    {%- assign image_width = '450, 650, 800, 1000, 1400' -%}
-    {%- assign image_sizes = '(min-width: 320px) 450px, (min-width: 480px) 650px, (min-width: 576px) 800px, (min-width: 768px) 1000px, (min-width: 1200px) 1400px' -%}
+    {%- assign image_width = '240, 360, 576, 900, 1260, 1920' -%}
+    {%- assign image_sizes = '(max-width: 320px) 240px, (max-width: 480px) 360px, (max-width: 768px) 576px, (max-width: 1200px) 900px, (max-width: 1680px) 1260px, 1920px' -%}
   {%- when 'xxl' -%}
-    {%- assign image_width = '450, 650, 800, 1000, 1400, 2000, 2500, 3840' -%}
-    {%- assign image_sizes = '(min-width: 320px) 450px, (min-width: 480px) 650px, (min-width: 576px) 800px, (min-width: 768px) 1000px, (min-width: 1200px) 1400px, (min-width: 1680px) 2000px, (min-width: 2400px) 2500px, (min-width: 3000px) 3840px' -%}
+    {%- assign image_width = '320, 480, 768, 1200, 1680, 2560' -%}
+    {%- assign image_sizes = '(max-width: 320px) 320px, (max-width: 480px) 480px, (max-width: 768px) 768px, (max-width: 1200px) 1200px, (max-width: 1680px) 1680px, 2560px' -%}
 {%- endcase -%}
 
 {%- if custom_width != blank and custom_size != blank -%}


### PR DESCRIPTION
The media queries were incorrect and were always loading the smallest size of the image which would cause blurry images. Note that the first matching media query in the `srcset` is used, and the rest are ignored. First `min-width` would be matched (as for example 2000px viewport width is larger than 450px defined in query) and smallest image used.

Logic for choosing image size is changed. Now the image size defines the expected size relative to the viewport and media queries take care of loading the right image size.

For example:
A hero image would be approximately as wide as the whole viewport, so we would use the xxl size.
A testimonial image would be approximately as wide as half of the viewport (as it is show on the side), so we would use the l size.

**Before**
![Screenshot 2023-11-10 at 16 30 49](https://github.com/booqable/tough-theme/assets/690113/7d10bb7d-49a4-45f8-901d-f8903abb63f7)

**After**
![Screenshot 2023-11-10 at 16 31 12](https://github.com/booqable/tough-theme/assets/690113/8ffc98c3-37eb-4ec8-8aac-2bdf47c44a05)
