### PR TITLE
Fix big payments icons

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -101,7 +101,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -233,7 +234,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -365,7 +367,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -528,7 +531,8 @@
             "padding_top": "medium",
             "padding_top_mobile": "small",
             "padding_bottom": "medium",
-            "padding_bottom_mobile": "small"
+            "padding_bottom_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -666,7 +670,8 @@
             "padding_top": "medium",
             "padding_top_mobile": "small",
             "padding_bottom": "medium",
-            "padding_bottom_mobile": "small"
+            "padding_bottom_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -804,7 +809,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -942,7 +948,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -1081,7 +1088,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }
@@ -1212,7 +1220,8 @@
             "padding_bottom": "medium",
             "padding_bottom_mobile": "small",
             "padding_top": "medium",
-            "padding_top_mobile": "small"
+            "padding_top_mobile": "small",
+            "show_payments": true
           },
           "disabled": null
         }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -9,6 +9,7 @@
 {%- assign padding_bottom         = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile     = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile  = section.settings.padding_bottom_mobile -%}
+{%- assign show_payments          = section.settings.show_payments -%}
 {%- assign facebook               = settings.social_facebook_link -%}
 {%- assign instagram              = settings.social_instagram_link -%}
 {%- assign twitter                = settings.social_twitter_link -%}
@@ -134,7 +135,7 @@
         </div>
       {%- endif -%}
 
-      {%- if payment_methods.size > 0 -%}
+      {%- if show_payments and payment_methods.size > 0 -%}
         <div class="footer__payments payments">
           {%- include "payments" -%}
         </div>
@@ -262,6 +263,12 @@
         "id": "bottom_menu",
         "label": "Bottom menu",
         "info": "This menu located at the bottom of footer"
+      },
+      {
+        "type": "checkbox",
+        "id": "show_payments",
+        "label": "Show payment icons",
+        "default": true
       },
       {
         "type": "header",

--- a/snippets/payments.liquid
+++ b/snippets/payments.liquid
@@ -11,11 +11,48 @@
 {% style %}
   .payment {
     padding: 0 16px 0 0;
-    margin: 0 calc(-1 * (var(--social-spacing, 6px) - 6px));
+    margin: 0 calc(-1 * (var(--social-spacing) - 4px));
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
   }
 
   .payment i {
-    margin: 0 calc(var(--social-spacing, 6px) - 6px);
+    margin: 0 calc(var(--social-spacing) - 4px);
+  }
+
+  .payment span {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .payment svg {
+    width: 35px;
+    height: 31px;
+  }
+
+  .palette-one .payment span:not([title="Bancontact"]) path {
+    fill: var(--color-primary, #0B1A26);
+  }
+
+  .palette-two .payment span:not([title="Bancontact"]) path {
+    fill: var(--color-primary-2, #FFFFFF);
+  }
+
+  .palette-three .payment span:not([title="Bancontact"]) path {
+    fill: var(--color-primary-3, #0B1A26);
+  }
+
+  .palette-one .payment span[title="Bancontact"] .st1 {
+    fill: var(--color-primary, #0B1A26);
+  }
+
+  .palette-two .payment span[title="Bancontact"] .st1 {
+    fill: var(--color-primary-2, #FFFFFF);
+  }
+
+  .palette-three .payment span[title="Bancontact"] .st1 {
+    fill: var(--color-primary-3, #0B1A26);
   }
 {% endstyle %}
 


### PR DESCRIPTION
There is an issue that the SVG icons of the payment methods in the footer are really big.

So there was added some styles to make them the same size

Before:
![Google Chrome_2023-11-13 10-57-38@2x](https://github.com/booqable/tough-theme/assets/40244261/7b9629cd-35d2-4345-b4a1-c59463359a21)


After:
![Google Chrome_2023-11-13 10-51-38@2x](https://github.com/booqable/tough-theme/assets/40244261/96bd178e-ade7-4aa0-8f46-0698268e234d)
