### PR TITLE
Added styles applied within the product description

### DIFF
--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -85,8 +85,12 @@
       {%- if custom_description != blank -%}
         <div class="hero__description text-medium bq-content rx-content">{{- custom_description -}}</div>
       {%- else -%}
-        {%- if page_description != blank -%}
-          <div class="hero__description text-medium">{{- page_description -}}</div>
+        {%- if template == "collection" -%}
+          <div class="hero__description text-medium bq-content rx-content">{{- collection.description -}}</div>
+        {%- else -%}
+          {%- if page_description != blank -%}
+            <div class="hero__description text-medium bq-content rx-content">{{- page_description -}}</div>
+          {%- endif -%}
         {%- endif -%}
       {%- endif -%}
     </div>

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -126,7 +126,7 @@
           </div>
 
           {%- if description != blank -%}
-            <div class="product-main__description">
+            <div class="product-main__description bq-content rx-content">
               {{- description -}}
             </div>
           {%- endif -%}


### PR DESCRIPTION
If in the product description add some additional elements, for example, an unordered list, it looks like the styles are not applied for the product description on the Product page

Before:
![Google Chrome_2023-11-13 16-42-35@2x](https://github.com/booqable/tough-theme/assets/40244261/9da2f2c4-0679-4464-959e-e2b29c64541b)

After:
![Google Chrome_2023-11-13 16-42-00@2x](https://github.com/booqable/tough-theme/assets/40244261/7915d84b-0c94-4143-85fc-e88ec1959c99)
