### PR TITLE
Fix: "Locations" and "Contact Form" incompatibility

### DIFF
--- a/assets/maps.js
+++ b/assets/maps.js
@@ -1,4 +1,4 @@
-class Map {
+class LocationMap {
   constructor(block) {
     this.block = block;
 
@@ -144,7 +144,7 @@ const initMap = (el = ".locations__wrapper") => {
   if (!nodes.length) return false;
 
   nodes.forEach(node => {
-    const maps = new Map(node);
+    const maps = new LocationMap(node);
     maps.init();
   })
 }


### PR DESCRIPTION
## Description

The issue was that the class responsible for initializing the maps for "Locations" section was called `Map` which was basically overwriting the native JavaScript class and the original was used in the reCaptcha. This PR resolves the issue by renaming the class from `Map` to `LocationMap`