### PR TITLE
Fixed bug of default colors of the date picker colors is showing always

### DIFF
--- a/assets/hero.css
+++ b/assets/hero.css
@@ -110,18 +110,10 @@
   max-height: 100%;
 }
 
-.hero .date-picker__instance {
+.hero .hero__wrapper .date-picker__instance {
   position: relative;
   z-index: 1;
   padding-top: 16px;
-}
-
-.hero__wrapper.section-with-date-picker .hero__container--padding-bottom {
-  padding-bottom: calc(var(--padding-bottom-mobile, 60px) + var(--date-picker-block-height, 70px));
-}
-
-.hero__wrapper--product.section-with-date-picker .date-picker__instance {
-  position: static;
 }
 
 .palette-one.hero__wrapper {
@@ -221,9 +213,5 @@
   .hero__date-picker--padding-bottom,
   .hero__container--padding-bottom {
     padding-bottom: var(--padding-bottom, 60px);
-  }
-
-  .hero__wrapper.section-with-date-picker .hero__container--padding-bottom {
-    padding-bottom: calc(var(--padding-bottom, 60px) + var(--date-picker-block-height, 70px));
   }
 }

--- a/assets/hero.css
+++ b/assets/hero.css
@@ -120,6 +120,10 @@
   padding-bottom: calc(var(--padding-bottom-mobile, 60px) + var(--date-picker-block-height, 70px));
 }
 
+.hero__wrapper--product.section-with-date-picker .date-picker__instance {
+  position: static;
+}
+
 .palette-one.hero__wrapper {
   color: var(--color-secondary, #4E5D78);
   background: var(--background-primary, #FFFFFF);

--- a/sections/hero-product.liquid
+++ b/sections/hero-product.liquid
@@ -36,7 +36,7 @@
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
 
-  <div class="hero__wrapper hero__wrapper--product section-with-date-picker{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
+  <div class="hero__wrapper section-with-date-picker{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
     <div class="hero__date-picker date-picker{% if padding_top != blank or padding_top_mobile != blank %} hero__date-picker--padding-top{%- endif -%}">
       {%- render 'date-picker',
           key: section.key,

--- a/sections/hero-product.liquid
+++ b/sections/hero-product.liquid
@@ -1,14 +1,14 @@
-{{ "hero.css" | asset_url | stylesheet_tag }}
-
-{%- assign show_datepicker       = section.settings.show_datepicker -%}
-{%- assign image                 = section.settings.image -%}
-{%- assign color_palette         = section.settings.color_palette -%}
-{%- assign padding_top           = section.settings.padding_top -%}
-{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign show_datepicker = section.settings.show_datepicker -%}
 
 {%- if show_datepicker -%}
+  {{ "hero.css" | asset_url | stylesheet_tag }}
+
+  {%- assign image              = section.settings.image -%}
+  {%- assign color_palette      = section.settings.color_palette -%}
+  {%- assign padding_top        = section.settings.padding_top -%}
+  {%- assign padding_top_mobile = section.settings.padding_top_mobile -%}
+
   {%- render 'background-accent', color_palette: color_palette -%}
-{%- endif -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -36,19 +36,19 @@
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
 
-<div class="hero__wrapper{% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if show_datepicker %} section-with-date-picker{%- endif -%}" style="{{- variables | escape -}}">
-  {%- if show_datepicker -%}
+  <div class="hero__wrapper hero__wrapper--product section-with-date-picker{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
     <div class="hero__date-picker date-picker{% if padding_top != blank or padding_top_mobile != blank %} hero__date-picker--padding-top{%- endif -%}">
       {%- render 'date-picker',
           key: section.key,
           color_palette: color_palette,
           background: background_accent,
           position: "bottom",
-          title: nil
+          title: nil,
+          settings: settings
       -%}
     </div>
-  {%- endif -%}
-</div>
+  </div>
+{%- endif -%}
 
 {% schema %}
   {

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -114,7 +114,8 @@
           color_palette: color_palette,
           background: background_accent,
           position: "bottom",
-          title: nil
+          title: nil,
+          settings: settings
       -%}
     </div>
   {%- endif -%}

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -85,7 +85,8 @@
           color_palette: color_palette,
           background: background_accent,
           position: "bottom",
-          title: nil
+          title: nil,
+          settings: settings
       -%}
     </div>
   {%- endif -%}

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -131,7 +131,8 @@
             color_palette: color_palette,
             background: background_accent,
             position: datepicker_position,
-            title: datepicker_title
+            title: datepicker_title,
+            settings: settings
         -%}
       </div>
     {%- endcapture -%}

--- a/sections/split-screen.liquid
+++ b/sections/split-screen.liquid
@@ -98,7 +98,8 @@
           color_palette: color_palette,
           background: background_accent,
           position: datepicker_position,
-          title: datepicker_title
+          title: datepicker_title,
+          settings: settings
       -%}
     </div>
   {%- endcapture -%}

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -6,7 +6,8 @@
   color_palette: "string" *required,
   background: "string" *required,
   position: "string" optional,
-  title: "string" optional
+  title: "string" optional,
+  settings: settings *required (global store settings)
 
   Usage:
 
@@ -15,7 +16,8 @@
       color_palette: color_palette,
       background: background_accent,
       position: datepicker_position,
-      title: datepicker_title
+      title: datepicker_title,
+      settings: settings
   -%}
 
 {% endcomment %}
@@ -62,7 +64,7 @@
     right: 0;
     bottom: 0;
     height: calc(var(--date-picker-height, 75px) / 2);
-    z-index: -1;
+    z-index: 0;
     background: var(--background-primary, #FFFFFF);
   }
 


### PR DESCRIPTION
Since more and more sections are using the `Date picker`, there were changes to its snippet recently. And the `global` store settings didn't transmit to the snippet. So the purpose is to pass `global settings` from all sections that use the Date picker to its snippet.

Also, the Hero section's code was cleaned up on the Product page.