### PR TITLE
Hide Locations and Split screen sections in the editor

### DIFF
--- a/sections/locations.liquid
+++ b/sections/locations.liquid
@@ -1,3 +1,9 @@
+{% comment %}
+  NOT AVAILABLE IN EDITOR
+  This section is not available in the theme editor at this point.
+  We will add in the future when we resolve UX issues with the map.
+{% endcomment %}
+
 {%- assign locations_array     = "" -%}
 
 {%- for block in section.blocks -%}
@@ -217,6 +223,7 @@
     "tag": "section",
     "class": "locations",
     "description": "Show the addresses of your locations with a map",
+    "templates": [],
     "max_blocks": 16,
     "blocks":[
       {

--- a/sections/split-screen.liquid
+++ b/sections/split-screen.liquid
@@ -1,3 +1,9 @@
+{% comment %}
+  NOT AVAILABLE IN EDITOR
+  This section is not available in the theme editor at this point.
+  We will add in the future when we confirm it has its place as it is similar to "Text with image" section.
+{% endcomment %}
+
 {{ "split-screen.css" | asset_url | stylesheet_tag }}
 
 {%- assign image                 = section.settings.image -%}
@@ -173,6 +179,7 @@
     "tag": "section",
     "class": "split-screen",
     "description": "Engage visitors by giving great first impression",
+    "templates": [],
     "settings": [
       {
         "type": "header",


### PR DESCRIPTION
We are going to hide two sections from the theme editor.

**Locations** - these were accidentally released early and still need some refinement.

**Split screen** - this was just developed but there was an oversight on product level as a very similar section still exists. There are concerns that this will confuse customers and add more code to maintain in the future. We will leave it in the code base for now but make it unavailable to customers.