### PR TITLE
Image slider controls overlap the CTA buttons

### DIFF
--- a/assets/images.css
+++ b/assets/images.css
@@ -203,7 +203,7 @@
 
 @media (min-width: 992px) {
   .images__container {
-    height: calc(var(--height, auto) - var(--header-height, 105px));
+    min-height: calc(var(--height, auto) - var(--header-height, 105px));
   }
 
   .images__container--padding-top {
@@ -265,7 +265,7 @@
   }
 
   .images__wrapper.section-with-date-picker .images__container {
-    height: calc(var(--height, auto) - var(--header-height, 105px) + var(--date-picker-block-height, 70px) + var(--padding-bottom, 60px));
+    min-height: calc(var(--height, auto) - var(--header-height, 105px) + var(--date-picker-block-height, 70px) + var(--padding-bottom, 60px));
   }
 
   .images__wrapper.section-with-date-picker .images__container--padding-bottom {


### PR DESCRIPTION
Added `min-height` instead of `height` CSS property on slide height for `Images` section on the desktop

Before: 

![Google Chrome_2023-12-05 12-58-12@2x](https://github.com/booqable/tough-theme/assets/40244261/4e1c4f1c-ec54-41c9-ac63-d9deeb1b9c79)


After:

![Screenshot_2023-12-05 12-57-36@2x](https://github.com/booqable/tough-theme/assets/40244261/329e4cf0-623c-473c-ab86-6dd3584dd3a8)
