### PR TITLE
Allow HTML in the description of the image section

### DIFF
--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -354,7 +354,7 @@
                         {%- endif -%}
 
                         {%- if description != blank -%}
-                          <div class="images__description text-medium bq-content rx-content">{{- description | strip_html | truncate: 150, " ..." -}}</div>
+                          <div class="images__description text-medium bq-content rx-content">{{- description -}}</div>
                         {%- endif -%}
 
                         {%- if datepicker_position == "in_text" -%}


### PR DESCRIPTION
We have a rich text editor for the description of the image field, but we are stripping HTML so styling is not displayed. This PR removes HTML stripping.

Additionally truncation is also removed as it can break HTML tags and cause issues in the layout.

Example:
`<p>Some long text</p>` can get truncated to `<p>Some long` which introduces an unclosed tag and breaks the layout.

