### PR TITLE
Use collection title as default hero title

### DIFF
--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -60,6 +60,8 @@
     <div class="hero__content">
       {%- if custom_title != blank -%}
         <h1 class="hero__title">{{- custom_title -}}</h1>
+      {%- elsif collection -%}
+        <h1 class="hero__title">{{- collection.title -}}</h1>
       {%- else -%}
         <h1 class="hero__title">{{- page_title -}}</h1>
       {%- endif -%}

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -6,7 +6,7 @@
       "blocks": {},
       "block_order": [],
       "settings": {
-        "custom_title": "{{ collection.title }}",
+        "custom_title": "",
         "color_palette": "two",
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",


### PR DESCRIPTION
Previously title of hero section would default to `page_title` on all pages. This looks good on most pages, but on collection pages it would render as "Collection name | Store name" which is not ideal.

With this change, default hero title will be collection title only.