### PR TITLE
Fixed issue when Date picker section doesn't take the selected colors

### DIFF
--- a/sections/date-picker.liquid
+++ b/sections/date-picker.liquid
@@ -65,7 +65,8 @@
           color_palette: color_palette,
           background: background_accent,
           position: nil,
-          title: title
+          title: title,
+          settings: settings
       -%}
     </div>
   </div>


### PR DESCRIPTION
The customer reported the issue, she is using the Construct theme, but the problem is that when she uses a date picker section, the date picker doesn't take the selected colors. It remains with the default theme color
Only the date picker included in the "images" section takes the correct color.

With a more detailed study of the problem revealed that the store settings were not passed to the date picker snippet

![image](https://github.com/booqable/tough-theme/assets/40244261/281c3c26-76cb-4ac6-bd30-a2f3541ebcf2)
