### PR TITLE
Fixed an issue where the "mobile image" was not displayed.

### DIFF
--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -418,7 +418,7 @@
                       {%- if image_mobile != blank -%}
                         <div class="images__vision-wrapper images__vision-wrapper--mobile{% if show_overlay %} images__vision-wrapper--overlay{%- endif -%}">
                           {%- render 'image',
-                            image: image,
+                            image: image_mobile,
                             loading: 'lazy',
                             class: 'images__image',
                             size: 'l'


### PR DESCRIPTION
The main purpose of this PR is to fix the issue reported by the customer when the `image mobile` was not rendered at all in the `Images` section.

Before:
![Google Chrome_2023-12-27 15-28-37@2x](https://github.com/booqable/tough-theme/assets/40244261/ae63d23e-ee59-417a-99ee-fb0366fea3eb)


After:
![Google Chrome_2023-12-27 15-27-24@2x](https://github.com/booqable/tough-theme/assets/40244261/4b949527-ba4f-4c33-a932-d2dde41d3690)
