### PR TITLE
Images not loaded in the 'all collection' on firefox

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -1,8 +1,7 @@
 .product-card {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: max-content 1fr;
   position: relative;
-  overflow: hidden;
   min-width: 298px;
 }
 


### PR DESCRIPTION
The issue is in `Product card` flexbox properties. Firefox browser doesn't want to work with `display: flex `and the `Product card` images aren't displayed all over the sections that use products.
So the solution is to change `display: flex` property to `display: grid`


Before:
![Firefox_2024-01-09 12-09-21@2x](https://github.com/booqable/tough-theme/assets/40244261/ce2e54dc-2d11-4e11-868b-2e5dd7e42a60)



After:
Firefox
![Firefox_2024-01-09 12-06-56@2x](https://github.com/booqable/tough-theme/assets/40244261/9e299b44-b831-4bdc-a38d-c3b0598cc53f)


Chrome
![Google Chrome_2024-01-09 12-07-53@2x](https://github.com/booqable/tough-theme/assets/40244261/8f3f0c29-6298-42d1-a2ec-5ab3eac27cd3)


Safari
![Safari_2024-01-09 12-07-18@2x](https://github.com/booqable/tough-theme/assets/40244261/deb33302-64bc-4aae-81c8-a7198336460c)

