### PR TITLE
Fixed indents if `none` option is chosen

### DIFF
--- a/assets/images.css
+++ b/assets/images.css
@@ -14,15 +14,15 @@
 }
 
 .images__container--padding-top {
-  padding-top: var(--padding-top-mobile, 40px);
+  padding-top: var(--padding-top-mobile, 0);
 }
 
 .images__container--padding-bottom {
-  padding-bottom: var(--padding-bottom-mobile, 40px);
+  padding-bottom: var(--padding-bottom-mobile, 0);
 }
 
 .images__text-area {
-  height: 100%;
+  flex: 1 1 auto;
   display: flex;
   justify-content: var(--text-justify-content-mobile, flex-start);
   align-items: var(--text-align-items-mobile, flex-start);
@@ -207,11 +207,11 @@
   }
 
   .images__container--padding-top {
-    padding-top: var(--padding-top, 60px);
+    padding-top: var(--padding-top, 0);
   }
 
   .images__container--padding-bottom {
-    padding-bottom: var(--padding-bottom, 60px);
+    padding-bottom: var(--padding-bottom, 0);
   }
 
   .images__vision-wrapper {
@@ -265,11 +265,11 @@
   }
 
   .images__wrapper.section-with-date-picker .images__container {
-    min-height: calc(var(--height, auto) - var(--header-height, 105px) + var(--date-picker-block-height, 70px) + var(--padding-bottom, 60px));
+    min-height: calc(var(--height, auto) - var(--header-height, 105px) + var(--date-picker-block-height, 70px) + var(--padding-bottom, 0px));
   }
 
   .images__wrapper.section-with-date-picker .images__container--padding-bottom {
-    padding-bottom: calc(var(--padding-bottom, 60px) + var(--date-picker-block-height, 70px));
+    padding-bottom: calc(var(--padding-bottom, 0px) + var(--date-picker-block-height, 70px));
   }
 }
 

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -52,8 +52,6 @@
     {%- endcase -%}
 
     {%- case padding_top -%}
-      {%- when 'none' -%}
-        --padding-top: 0;
       {%- when 'small' -%}
         --padding-top: 24px;
       {%- when 'medium' -%}
@@ -63,8 +61,6 @@
     {%- endcase -%}
 
     {%- case padding_bottom -%}
-      {%- when 'none' -%}
-        --padding-bottom: 0;
       {%- when 'small' -%}
         --padding-bottom: 24px;
       {%- when 'medium' -%}
@@ -74,8 +70,6 @@
     {%- endcase -%}
 
     {%- case padding_top_mobile -%}
-      {%- when 'none' -%}
-        --padding-top-mobile: 0;
       {%- when 'small' -%}
         --padding-top-mobile: 24px;
       {%- when 'medium' -%}
@@ -85,8 +79,6 @@
     {%- endcase -%}
 
     {%- case padding_bottom_mobile -%}
-      {%- when 'none' -%}
-        --padding-bottom-mobile: 0;
       {%- when 'small' -%}
         --padding-bottom-mobile: 24px;
       {%- when 'medium' -%}


### PR DESCRIPTION
The main purpose of this PR is to fix a bug reported by the Product team if the padding-bottom option has the value `none` the carousel height is flattened and the second purpose is to fix the issue of `text positioning` inside the slide

![image](https://github.com/booqable/tough-theme/assets/40244261/60ab7bb1-8671-4248-b896-695aa039dd86)
![image (1)](https://github.com/booqable/tough-theme/assets/40244261/ff164fc9-0fe3-402d-b1b7-bffd52635933)
