### PR TITLE
Allowing setting opacity for overlay in Hero and CTA sections

### DIFF
--- a/assets/call-to-action.css
+++ b/assets/call-to-action.css
@@ -78,6 +78,7 @@
   top: 0;
   bottom: -120px;
   right: 0;
+  opacity: var(--overlay-opacity, 1);
 }
 
 .cta__image-floral-wrapper {

--- a/assets/hero.css
+++ b/assets/hero.css
@@ -60,6 +60,7 @@
   left: 50%;
   top: 0;
   transform: translate(-50%, 0);
+  opacity: var(--overlay-opacity, 1);
 }
 
 .hero__vision-wrapper-overlay:after {

--- a/assets/hero.css
+++ b/assets/hero.css
@@ -82,7 +82,7 @@
 }
 
 .hero__image {
-  opacity: 0.1;
+  opacity: calc(100% - var(--overlay-opacity, 1));
   width: 100%;
   height: 100%;
   max-width: none;
@@ -96,7 +96,7 @@
   transform: translate(-50%, -50%);
   height: 100%;
   min-width: 100%;
-  opacity: 0.1;
+  opacity: calc(100% - var(--overlay-opacity, 1));
 }
 
 .hero__vision-floral-wrapper {

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -47,7 +47,7 @@
   margin-bottom: 6px;
 }
 
-.product-info__availability,
+.product-main__availability,
 .product-main__variation {
   padding: 0 0 32px;
 }
@@ -56,16 +56,16 @@
   display: block;
 }
 
-.product-info__availability bq-product-availability {
+.product-main__availability bq-product-availability {
   font-family: var(--font-body, sans-serif);
   font-size: 14px;
 }
 
-.product-info__availability bq-product-availability[visible="true"] {
+.product-main__availability bq-product-availability[visible="true"] {
   margin-right: 20px;
 }
 
-.product-info__availability bq-product-availability-calendar {
+.product-main__availability bq-product-availability-calendar {
   font-size: 16px;
   font-family: var(--font-body, sans-serif);
   line-height: var(--line-height-lg, 1.5);
@@ -75,7 +75,7 @@
   transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
 }
 
-.product-info__availability bq-product-availability-calendar:hover {
+.product-main__availability bq-product-availability-calendar:hover {
   text-decoration: none !important;
 }
 

--- a/sections/call-to-action.liquid
+++ b/sections/call-to-action.liquid
@@ -8,6 +8,7 @@
 {%- assign button_url_2          = section.settings.button_url_2 -%}
 {%- assign image                 = section.settings.image -%}
 {%- assign color_palette         = section.settings.color_palette -%}
+{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
 {%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -16,6 +17,8 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
+  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+
   {%- case padding_top -%}
       {%- when 'none' -%}
         --padding-top: 0;
@@ -148,6 +151,14 @@
         "type": "image_picker",
         "id": "image",
         "label": "Background image"
+      },
+      {
+        "type": "number",
+        "id": "overlay_opacity",
+        "label": "Overlay percentage",
+        "min": 0,
+        "max": 100,
+        "default": 100
       },
       {
         "type": "select",

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -6,6 +6,7 @@
 {%- assign button_label          = section.settings.button_label -%}
 {%- assign image                 = section.settings.image -%}
 {%- assign color_palette         = section.settings.color_palette -%}
+{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
 {%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -20,6 +21,8 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
+  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+
   {%- case padding_top -%}
     {%- when 'small' -%}
       --padding-top: 43px;
@@ -166,6 +169,14 @@
         "type": "image_picker",
         "id": "image",
         "label": "Background image"
+      },
+      {
+        "type": "number",
+        "id": "overlay_opacity",
+        "label": "Overlay percentage",
+        "min": 0,
+        "max": 100,
+        "default": 100
       },
       {
         "type": "text",

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -176,7 +176,7 @@
         "label": "Overlay percentage",
         "min": 0,
         "max": 100,
-        "default": 100
+        "default": 80
       },
       {
         "type": "text",

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -5,6 +5,7 @@
 {%- assign show_datepicker       = section.settings.show_datepicker -%}
 {%- assign image                 = section.settings.image -%}
 {%- assign color_palette         = section.settings.color_palette -%}
+{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
 {%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -17,6 +18,8 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
+  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+
   {%- case padding_top -%}
     {%- when 'small' -%}
       --padding-top: 50px;
@@ -126,6 +129,14 @@
         "type": "image_picker",
         "id": "image",
         "label": "Background image"
+      },
+      {
+        "type": "number",
+        "id": "overlay_opacity",
+        "label": "Overlay percentage",
+        "min": 0,
+        "max": 100,
+        "default": 100
       },
       {
         "type": "text",

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -136,7 +136,7 @@
         "label": "Overlay percentage",
         "min": 0,
         "max": 100,
-        "default": 100
+        "default": 80
       },
       {
         "type": "text",

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -1,5 +1,4 @@
 {{ "product-page.css" | asset_url | stylesheet_tag }}
-{{ "accordion.css" | asset_url | stylesheet_tag }}
 
 {%- assign title                 = product.name -%}
 {%- assign description           = product.description -%}
@@ -16,8 +15,6 @@
 {%- assign show_breadcrumbs      = section.settings.show_breadcrumbs -%}
 {%- assign breadcrumbs_label     = section.settings.breadcrumbs_label -%}
 {%- assign breadcrumbs_url       = section.settings.breadcrumbs_url -%}
-{%- assign blocks                = section.blocks -%}
-{%- assign is_focal              = settings.use_focal_images -%}
 
 {%- assign label = "" -%}
 
@@ -108,7 +105,7 @@
     -%}
 
     <div class="product-main__wrapper">
-      <div class="product-main__gallery"">
+      <div class="product-main__gallery">
         {{ product | product_gallery:
           enable_thumbnails: show_thumbnails,
           enable_controls: show_controls,
@@ -145,12 +142,12 @@
             {{- product | bundle_items -}}
           </div>
 
-          <div class="product-info__availability">
+          <div class="product-main__availability">
             {{- product | product_availability -}}
             {{- product | availability_calendar -}}
           </div>
 
-          <div class="product-info__quantity">
+          <div class="product-main__quantity">
             {{- product | product_button -}}
           </div>
 

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -6,6 +6,8 @@
       "blocks": {},
       "block_order": [],
       "settings": {
+        "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -8,7 +8,7 @@
       "settings": {
         "custom_title": "",
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -8,6 +8,7 @@
       "settings": {
         "custom_title": "",
         "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/construct/list-collections.json
+++ b/templates/construct/list-collections.json
@@ -9,7 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/construct/list-collections.json
+++ b/templates/construct/list-collections.json
@@ -9,6 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -9,7 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -9,6 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/page.json
+++ b/templates/page.json
@@ -6,6 +6,8 @@
       "blocks": {},
       "block_order": [],
       "settings": {
+        "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/page.json
+++ b/templates/page.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/romance/list-collections.json
+++ b/templates/romance/list-collections.json
@@ -9,7 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/romance/list-collections.json
+++ b/templates/romance/list-collections.json
@@ -9,6 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/search.json
+++ b/templates/search.json
@@ -9,6 +9,7 @@
         "button_label": "Browse products",
         "color_palette": "two",
         "message": "No results found",
+        "overlay_opacity": 100,
         "padding_bottom": "large",
         "padding_bottom_mobile": "large",
         "padding_top": "large",

--- a/templates/vogue/list-collections.json
+++ b/templates/vogue/list-collections.json
@@ -9,7 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
-        "overlay_opacity": 100,
+        "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",

--- a/templates/vogue/list-collections.json
+++ b/templates/vogue/list-collections.json
@@ -9,6 +9,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "color_palette": "two",
+        "overlay_opacity": 100,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",


### PR DESCRIPTION
The background image is pretty much useless because of the non-adjustable overlay.
So it should have a setting of opacity percentage as we have in other sections e.g. `Images`.

Before:

![Google Chrome_2024-01-19 13-21-52@2x](https://github.com/booqable/tough-theme/assets/40244261/37c7e54f-fe2a-48ea-a1d4-5c2f7dc9dc38)
![Google Chrome_2024-01-19 13-23-50@2x](https://github.com/booqable/tough-theme/assets/40244261/450d6af8-48ee-4902-af3d-b48fd5661258)


After:

![Google Chrome_2024-01-19 13-22-14@2x](https://github.com/booqable/tough-theme/assets/40244261/90badb78-8ee4-4759-84fa-082e7c9ddc95)
![Google Chrome_2024-01-19 13-23-11@2x](https://github.com/booqable/tough-theme/assets/40244261/06f9a77f-a404-40ea-ba79-0242a420f689)
