### PR TITLE
Move flash messages above the forms

### DIFF
--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -69,6 +69,18 @@
       </div>
     {%- endif -%}
 
+    {%- if alert -%}
+      <div class="account__alert account__alert--danger">
+        {{- alert -}}
+      </div>
+    {%- endif -%}
+
+    {%- if notice -%}
+      <div class="account__alert account__alert--info">
+        {{- notice -}}
+      </div>
+    {%- endif -%}
+
     {%- form 'login' -%}
       <div class="account-fieldset__block">
         <label for="user_email" class="account-fieldset__label">
@@ -114,18 +126,6 @@
           {{- reset_password_label | default: "Forgot your password?" -}}
         </a>
       </div>
-
-      {%- if alert -%}
-        <div class="account__alert account__alert--danger">
-          {{- alert -}}
-        </div>
-      {%- endif -%}
-
-      {%- if notice -%}
-        <div class="account__alert account__alert--info">
-          {{- notice -}}
-        </div>
-      {%- endif -%}
 
       <div class="account__divider">
         <button

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -78,6 +78,10 @@
       </a>
     </div>
 
+    {%- if alert -%}
+      <div class="account__alert">{{- alert -}}</div>
+    {%- endif -%}
+
     {%- form 'register' -%}
       <div class="account-fieldset__block{% if form.errors.name %} account-fieldset--error{%- endif -%}">
         <label for="user_name" class="account-fieldset__label">
@@ -238,10 +242,6 @@
           {{- form.errors.agreement_accepted -}}
         </div>
       </div>
-
-      {%- if alert -%}
-        <div class="account__alert">{{- alert -}}</div>
-      {%- endif -%}
 
       <button
         type="submit"


### PR DESCRIPTION
Flash messages contain important information that you should read before trying to log in, so we're moving them above the form.

# Before
![Screenshot 2024-01-26 at 15 05 34](https://github.com/booqable/tough-theme/assets/690113/ca288c2c-45e6-4006-9437-13e2b5cc153c)

# After
![Screenshot 2024-01-26 at 15 09 10](https://github.com/booqable/tough-theme/assets/690113/d19a3031-2926-4dd1-871e-f201fdf944b3)
