### PR TITLE
Hide price separator

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -59,6 +59,10 @@
   flex-grow: 0;
 }
 
+.product-card__description:last-child {
+  padding-bottom: 0;
+}
+
 .product-card__price-info {
   font-size: 16px;
   font-weight: var(--font-weight-regular, 400);

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -2,6 +2,14 @@
 
 {%- assign title                 = product.name -%}
 {%- assign description           = product.description -%}
+{%- assign variants              = product.variants -%}
+{%- assign variant_selector      = product | product_variations_select -%}
+{%- assign bundle_items          = product | bundle_items -%}
+{%- assign availability          = product | product_availability -%}
+{%- assign availability_calendar = product | availability_calendar -%}
+{%- assign quantity              = product | product_button -%}
+{%- assign price                 = product | product_price -%}
+{%- assign period                = product | product_price_label -%}
 {%- assign variation_label       = section.settings.variation_label -%}
 {%- assign message_label         = section.settings.message_label -%}
 {%- assign show_controls         = section.settings.show_controls -%}
@@ -117,9 +125,11 @@
           <h1 class="product-main__title">{{- title -}}</h1>
 
           <div class="product-main__price">
-            {{- product | product_price -}}
-            <span class="product-main__price-separator">/</span>
-            {{- product | product_price_label -}}
+            {%- if price and period -%}
+              {{- price -}}
+              <span class="product-main__price-separator">/</span>
+              {{- period -}}
+            {%- endif -%}
           </div>
 
           {%- if description != blank -%}
@@ -129,27 +139,21 @@
           {%- endif -%}
 
           <div class="product-main__variation">
-            {%- if product.variants.size > 1 -%}
-              <div class="product-main__variation-label">
-                {{- variation_label -}}
-              </div>
+            {%- if variants.size > 1 -%}
+              <div class="product-main__variation-label">{{- variation_label -}}</div>
 
-              <div class="product-main__variation-select">
-                {{- product | product_variations_select -}}
-              </div>
+              <div class="product-main__variation-select">{{- variant_selector -}}</div>
             {%- endif -%}
 
-            {{- product | bundle_items -}}
+            {{- bundle_items -}}
           </div>
 
           <div class="product-main__availability">
-            {{- product | product_availability -}}
-            {{- product | availability_calendar -}}
+            {{- availability -}}
+            {{- availability_calendar -}}
           </div>
 
-          <div class="product-main__quantity">
-            {{- product | product_button -}}
-          </div>
+          <div class="product-main__quantity">{{- quantity -}}</div>
 
           {%- if message_label != blank -%}
             <div class="product-main__shipping-info">

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -104,12 +104,14 @@
       <div class="product-card__description">{{- excerpt -}}</div>
     {%- endif -%}
 
-    <div class="product-card__price-info">
-      <div class="product-card__price-wrapper">
-        <span class="product-card__price">{{- price -}}</span>
-        <span class="product-card__price-separator">/</span>
-        <span class="product-card__period">{{- period -}}</span>
+    {%- if price != blank and period != blank -%}
+      <div class="product-card__price-info">
+        <div class="product-card__price-wrapper">
+          <span class="product-card__price">{{- price -}}</span>
+          <span class="product-card__price-separator">/</span>
+          <span class="product-card__period">{{- period -}}</span>
+        </div>
       </div>
-    </div>
+    {%- endif -%}
   </div>
 </div>


### PR DESCRIPTION
The purpose of the PR is to hide price separator when the prices are hidden from the store

Before:
![Google Chrome_2024-02-05 19-17-53@2x](https://github.com/booqable/tough-theme/assets/40244261/16a700e7-68d6-4f71-86a4-fc12f74df526)
![Google Chrome_2024-02-05 19-17-25@2x](https://github.com/booqable/tough-theme/assets/40244261/c983ed23-5f92-4368-b308-a7aa6285509f)


After:
![Google Chrome_2024-02-05 19-14-12@2x](https://github.com/booqable/tough-theme/assets/40244261/15c4b9bc-a524-4bb7-b8d7-0ffab138e9b3)
![Google Chrome_2024-02-05 19-13-44@2x](https://github.com/booqable/tough-theme/assets/40244261/1f7bdafd-8f91-4bd0-810a-41cb2fe9b2d5)
