### PR TITLE
`Terms & Agreement` modal window

### DIFF
--- a/assets/account.css
+++ b/assets/account.css
@@ -138,6 +138,10 @@
   margin-left: 0;
 }
 
+.account__link {
+  text-decoration: none;
+}
+
 .account__agreement-opener {
   cursor: pointer;
   transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
@@ -151,6 +155,7 @@
   margin-bottom: 10px;
 }
 
+.account-checkbox__label .account__link,
 .account-checkbox__label .account__agreement-opener {
   margin-left: 4px;
 }
@@ -439,14 +444,17 @@ div.account-fieldset--error .account-fieldset__input:focus {
   background: var(--background-primary, #FFFFFF);
 }
 
+.palette-one .account__link,
 .palette-one .account__agreement-opener {
   color: var(--color-outline, #F4B841);
 }
 
+.palette-one .account__link:hover,
 .palette-one .account__agreement-opener:hover {
   color: var(--color-outline-hover, #F4B841CC);
 }
 
+.palette-one .account__link:active,
 .palette-one .account__agreement-opener:active {
   color: var(--color-outline-active, #F4B841BA);
 }
@@ -538,14 +546,17 @@ div.account-fieldset--error .account-fieldset__input:focus {
   background: var(--background-primary-2, #0B1A26);
 }
 
+.palette-two .account__link,
 .palette-two .account__agreement-opener {
   color: var(--color-outline-2, #F4B841);
 }
 
+.palette-two .account__link:hover,
 .palette-two .account__agreement-opener:hover {
   color: var(--color-outline-2-hover, #F4B841CC);
 }
 
+.palette-two .account__link:active,
 .palette-two .account__agreement-opener:active {
   color: var(--color-outline-2-active, #F4B841BA);
 }
@@ -633,14 +644,17 @@ div.account-fieldset--error .account-fieldset__input:focus {
   background: var(--background-primary-3, #F4B841);
 }
 
+.palette-three .account__link,
 .palette-three .account__agreement-opener {
   color: var(--color-outline-3, #0B1A26);
 }
 
+.palette-three .account__link:hover,
 .palette-three .account__agreement-opener:hover {
   color: var(--color-outline-3-hover, #0B1A26CC);
 }
 
+.palette-three .account__link:active,
 .palette-three .account__agreement-opener:active {
   color: var(--color-outline-3-active, #0B1A26BA);
 }

--- a/assets/account.css
+++ b/assets/account.css
@@ -138,8 +138,9 @@
   margin-left: 0;
 }
 
-.account__link {
-  text-decoration: none;
+.account__agreement-opener {
+  cursor: pointer;
+  transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
 }
 
 .account-checkbox__label {
@@ -150,11 +151,11 @@
   margin-bottom: 10px;
 }
 
-.account-checkbox__label .account__link {
+.account-checkbox__label .account__agreement-opener {
   margin-left: 4px;
 }
 
-.account-checkbox__label span {
+.account-checkbox__label > span {
   margin-left: 24px;
 }
 
@@ -188,6 +189,87 @@
   border: solid transparent;
   border-width: 0 2px 2px 0;
   transform: rotate(45deg) translate(-100%, -45%);
+}
+
+.account__agreement-modal {
+  display: block !important;
+  position: fixed;
+  top: calc(var(--header-height, 130px) + var(--header-transform, 0px));
+  left: 0;
+  width: 100%;
+  height: calc(100vh - var(--header-height, 130px) - var(--header-transform, 0px));
+  transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
+  padding: 10px;
+  backdrop-filter: blur(5px);
+  visibility: hidden;
+  opacity: 0;
+}
+
+.account__agreement-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: calc(var(--max-width-narrow, 770px) + 60px);
+  padding: 30px;
+  margin: 0 auto;
+  display: block;
+}
+
+.account__agreement-inner {
+  border: 1px solid transparent;
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: hidden;
+  border-radius: var(--border-radius-rounded, 0);
+}
+
+.account__agreement-text {
+  display: block;
+  padding: 16px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-radius: var(--border-radius-rounded, 0);
+}
+
+.account__agreement-closer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  text-indent: -9999px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
+}
+
+.account__agreement-closer:after,
+.account__agreement-closer:before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 23%;
+  right: 23%;
+  transform: rotate(45deg);
+  height: 2px;
+}
+
+.account__agreement-closer:after {
+  transform: rotate(-45deg);
+}
+
+.account__agreement-buttons {
+  padding-top: 16px;
+  margin: 0 0 calc(-1 * var(--button-margin-bottom));
+  display: block;
+  text-align: center;
+}
+
+[id^='user_agreement_opener']:checked ~ .account__agreement-modal {
+  visibility: visible;
+  opacity: 1;
 }
 
 .account__error-message {
@@ -347,18 +429,6 @@ div.account-fieldset--error .account-fieldset__input:focus {
   border-color: var(--background-accent-active, #F4B841BA);
 }
 
-.palette-one .account__link {
-  color: var(--color-outline, #F4B841);
-}
-
-.palette-one .account__link:hover {
-  color: var(--color-outline-hover, #F4B841CC);
-}
-
-.palette-one .account__link:active {
-  color: var(--color-outline-active, #F4B841BA);
-}
-
 .palette-one .account__alert--info {
   border: 1px solid var(--color-border, #0B1A2626);
 }
@@ -367,6 +437,38 @@ div.account-fieldset--error .account-fieldset__input:focus {
 .palette-one .account-checkbox__label:before {
   border-color: var(--color-border, #0B1A2626);
   background: var(--background-primary, #FFFFFF);
+}
+
+.palette-one .account__agreement-opener {
+  color: var(--color-outline, #F4B841);
+}
+
+.palette-one .account__agreement-opener:hover {
+  color: var(--color-outline-hover, #F4B841CC);
+}
+
+.palette-one .account__agreement-opener:active {
+  color: var(--color-outline-active, #F4B841BA);
+}
+
+.palette-one .account__agreement-inner {
+  background: var(--background-primary, #FFFFFF);
+  border-color: var(--color-border, #0B1A2626);
+}
+
+.palette-one .account__agreement-closer:after,
+.palette-one .account__agreement-closer:before {
+  background: var(--color-outline, #F4B841);
+}
+
+.palette-one .account__agreement-closer:hover:after,
+.palette-one .account__agreement-closer:hover:before {
+  background: var(--color-outline-hover, #F4B841CC);
+}
+
+.palette-one .account__agreement-closeractive:after,
+.palette-one .account__agreement-closer:active:before {
+  background: var(--color-outline-active, #F4B841BA);
 }
 
 .palette-one [id^='user_legal_type']:checked + .account-fieldset__radio-label:before,
@@ -426,18 +528,6 @@ div.account-fieldset--error .account-fieldset__input:focus {
   border-color: var(--background-accent-2-active, #F4B841BA);
 }
 
-.palette-two .account__link {
-  color: var(--color-outline-2, #F4B841);
-}
-
-.palette-two .account__link:hover {
-  color: var(--color-outline-2-hover, #F4B841CC);
-}
-
-.palette-two .account__link:active {
-  color: var(--color-outline-2-active, #F4B841BA);
-}
-
 .palette-two .account__alert--info {
   border: 1px solid var(--color-border-2, #FFFFFF47);
 }
@@ -446,6 +536,38 @@ div.account-fieldset--error .account-fieldset__input:focus {
 .palette-two .account-checkbox__label:before {
   border-color: var(--color-border-2, #FFFFFF47);
   background: var(--background-primary-2, #0B1A26);
+}
+
+.palette-two .account__agreement-opener {
+  color: var(--color-outline-2, #F4B841);
+}
+
+.palette-two .account__agreement-opener:hover {
+  color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+.palette-two .account__agreement-opener:active {
+  color: var(--color-outline-2-active, #F4B841BA);
+}
+
+.palette-two .account__agreement-inner {
+  background: var(--background-primary-2, #0B1A26);
+  border-color: var(--color-border-2, #FFFFFF47);
+}
+
+.palette-two .account__agreement-closer:after,
+.palette-two .account__agreement-closer:before {
+  background: var(--color-outline-2, #F4B841);
+}
+
+.palette-two .account__agreement-closer:hover:after,
+.palette-two .account__agreement-closer:hover:before {
+  background: var(--color-outline-2-hover, #F4B841CC);
+}
+
+.palette-two .account__agreement-closeractive:after,
+.palette-two .account__agreement-closer:active:before {
+  background: var(--color-outline-2-active, #F4B841BA);
 }
 
 .palette-two [id^='user_legal_type']:checked + .account-fieldset__radio-label:before,
@@ -501,18 +623,6 @@ div.account-fieldset--error .account-fieldset__input:focus {
   border-color: var(--background-accent-3-active, #0B1A26BA);
 }
 
-.palette-three .account__link {
-  color: var(--color-outline-3, #0B1A26);
-}
-
-.palette-three .account__link:hover {
-  color: var(--color-outline-3-hover, #0B1A26CC);
-}
-
-.palette-three .account__link:active {
-  color: var(--color-outline-3-active, #0B1A26BA);
-}
-
 .palette-three .account__alert--info {
   border: 1px solid var(--color-border-3, #0B1A2626);
 }
@@ -521,6 +631,38 @@ div.account-fieldset--error .account-fieldset__input:focus {
 .palette-three .account-checkbox__label:before {
   border-color: var(--color-border-3, #0B1A2626);
   background: var(--background-primary-3, #F4B841);
+}
+
+.palette-three .account__agreement-opener {
+  color: var(--color-outline-3, #0B1A26);
+}
+
+.palette-three .account__agreement-opener:hover {
+  color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+.palette-three .account__agreement-opener:active {
+  color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+.palette-three .account__agreement-inner {
+  background: var(--background-primary-3, #F4B841);
+  border-color: var(--color-border-3, #0B1A2626);
+}
+
+.palette-three .account__agreement-closer:after,
+.palette-three .account__agreement-closer:before {
+  background: var(--color-outline-3, #0B1A26);
+}
+
+.palette-three .account__agreement-closer:hover:after,
+.palette-three .account__agreement-closer:hover:before {
+  background: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+.palette-three .account__agreement-closeractive:after,
+.palette-three .account__agreement-closer:active:before {
+  background: var(--color-outline-3-active, #0B1A26BA);
 }
 
 .palette-three [id^='user_legal_type']:checked + .account-fieldset__radio-label:before,
@@ -545,6 +687,12 @@ div.account-fieldset--error .account-fieldset__input:focus {
   }
 }
 
+@media (min-width: 768px) {
+  .account__agreement-modal {
+    padding: 20px 50px;
+  }
+}
+
 @media screen and (min-width: 810px) {
   .account__title {
     font-size: 40px;
@@ -559,5 +707,11 @@ div.account-fieldset--error .account-fieldset__input:focus {
 
   .account--padding-bottom {
     padding-bottom: var(--padding-bottom, 40px);
+  }
+}
+
+@media (min-width: 1200px) {
+  .account__agreement-modal {
+    padding: 50px;
   }
 }

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -13,7 +13,8 @@
 {%- assign private_label         = section.settings.private_label -%}
 {%- assign company_label         = section.settings.company_label -%}
 {%- assign agree_label           = section.settings.agree_label -%}
-{%- assign agreements_label      = section.settings.agreements_label -%}
+{%- assign agreement_label       = section.settings.agreement_label -%}
+{%- assign button_label          = section.settings.button_label -%}
 {%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -228,13 +229,30 @@
           <span>
             {{- agree_label | default: "I agree to the" -}}
 
-            <a
-              class="account__link"
-              href="https://booqable.com/agreement"
-              target="_blank"
-            >
-              {{- agreements_label | default: "Terms and agreements" -}}
-            </a>
+            <span class="account__agreement">
+              <input type="checkbox" id="user_agreement_opener" style="display: none">
+              <label for="user_agreement_opener" class="account__agreement-opener">
+                {{- agreement_label | default: "Terms and agreements" -}}
+              </label>
+
+              <span class="account__agreement-modal bq-content rx-content" style="display: none">
+                <span class="account__agreement-content">
+                  <span class="account__agreement-inner">
+                    <label for="user_agreement_opener" class="account__agreement-closer">X</label>
+
+                    <span class="account__agreement-text">
+                      {{- form.agreement_content -}}
+
+                      <span class="account__agreement-buttons">
+                        <label class="account-checkbox__button button button--primary button--large" for="user_agreement_opener">
+                          {{ button_label | default: "Agree" }}
+                        </label>
+                      </span>
+                    </span>
+                  </span>
+                </span>
+              </span>
+            </span>
           </span>
         </label>
 
@@ -341,7 +359,7 @@
       },
       {
         "type": "text",
-        "id": "agreements_label",
+        "id": "agreement_label",
         "label": "Terms and agreements label"
       },
       {
@@ -357,6 +375,11 @@
         "type": "text",
         "id": "signup_label",
         "label": "Sign up button label"
+      },
+      {
+        "type": "text",
+        "id": "button_label",
+        "label": "Button label (Modal window)"
       },
       {
         "type": "header",

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -14,7 +14,7 @@
 {%- assign company_label         = section.settings.company_label -%}
 {%- assign agree_label           = section.settings.agree_label -%}
 {%- assign agreement_label       = section.settings.agreement_label -%}
-{%- assign button_label          = section.settings.button_label -%}
+{%- assign accept_button_label   = section.settings.accept_button_label -%}
 {%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
@@ -245,7 +245,7 @@
 
                       <span class="account__agreement-buttons">
                         <label class="account-checkbox__button button button--primary button--large" for="user_agreement_opener">
-                          {{ button_label | default: "Agree" }}
+                          {{ accept_button_label | default: "Agree" }}
                         </label>
                       </span>
                     </span>
@@ -378,8 +378,8 @@
       },
       {
         "type": "text",
-        "id": "button_label",
-        "label": "Button label (Modal window)"
+        "id": "accept_button_label",
+        "label": "Accept agreement button label (in modal window)"
       },
       {
         "type": "header",


### PR DESCRIPTION
The PR purpose is to introduce Terms & Agreement modal window

Clicked on the "Terms and agreements" link when creating a new customer account led you to a generic Booqable terms page. But should be the actual content of the terms and agreement that company provided. 

So in this PR implemented a modal that shows this content, instead of linking to the generic one.

![image (28) (2)](https://github.com/booqable/tough-theme/assets/40244261/5751f9f6-d80b-4e34-874c-c42d7c5857f5)
![Screenshot 2024-02-09 at 13 30 55](https://github.com/booqable/tough-theme/assets/40244261/ea91b5af-f3a3-4cf0-abcf-c15dc87bf070)

![Google Chrome_2024-02-13 15-21-15@2x](https://github.com/booqable/tough-theme/assets/40244261/d17cf8db-d400-41a8-968e-2c9ef7e75038)
