### PR TITLE
Keep type for logo image

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -117,7 +117,8 @@
         class: 'header__logo-image',
         custom_width: '200',
         custom_size: '200px',
-        custom_alt: shop.name
+        custom_alt: shop.name,
+        keep_type: true
     -%}
   {%- elsif custom_title != blank -%}
     <h2 class="header__logo-text">{{- custom_title -}}</h2>

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -81,5 +81,6 @@ xxl - Image is as wide as the whole viewport
   widths: image_width,
   sizes: image_sizes,
   focal: focal,
-  alt: alt
+  alt: alt,
+  keep_type: keep_type
 -}}


### PR DESCRIPTION
Make sure that we do not convert format of logo image. This enables customer to use `png` images which are sharper than the `webp` to which we convert by default.

Related [PR](https://github.com/saladdays-nl/booqable/pull/10073)