### PR TITLE
Add favico and shop title to checkout page

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -9,9 +9,9 @@
     <script src="https://kit.fontawesome.com/ff3b3de2b5.js" crossorigin="anonymous"></script>
     {{ content_for_header }}
 
-    <title>Checkout</title>
-
     {% render 'fonts', settings: settings %}
+
+    {% render 'page-metadata', shop: shop %}
   </head>
   <body>
 


### PR DESCRIPTION
Previously we forgot to add the metadata to the checkout. This PR makes sure:
- Favicon is included
- Shop name is used as the title of the page