### PR TITLE
Add support for rendering app blocks

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -180,6 +180,10 @@
   border-top-color: var(--color-border-3, #0B1A2626);
 }
 
+.footer-app {
+  margin-left: var(--horizontal-padding, 16px);
+}
+
 @media (min-width: 992px) {
   .footer__wrapper--padding-top {
     padding-top: var(--padding-top, 0px);

--- a/assets/header.css
+++ b/assets/header.css
@@ -23,7 +23,7 @@
 
 .header__content-inner {
   display: grid;
-  grid-template-columns: var(--header-grid-template-columns);
+  grid-template-columns: max-content 1fr max-content;
   gap: 0px 8px;
   grid-template-areas:
     "column-2 column-1 column-3";

--- a/assets/header.css
+++ b/assets/header.css
@@ -411,6 +411,15 @@
   color: var(--color-primary-3, #0B1A26);
 }
 
+header:has(.app-mobile) .header-app:has(.app-desktop) {
+  display: none;
+}
+
+.header-app:has(.app-mobile) {
+  display: flex;
+  margin: var(--padding-bottom-mobile, 16px) var(--horizontal-padding, 16px);
+}
+
 @media (min-width: 576px) {
   .header__search-wrapper {
     right: -25px;
@@ -437,6 +446,18 @@
 }
 
 @media (min-width: 1100px) and (hover: hover) {
+  .header-app:has(.app-mobile) {
+    display: none;
+  }
+
+  header:has(.app-mobile) .header-app:has(.app-desktop) {
+    display: initial;
+  }
+
+  .header-app:has(.app-desktop) {
+    margin-right: var(--horizontal-padding, 16px);
+  }
+
   .header__content-inner {
     grid-template-columns: max-content 1fr max-content;
     grid-template-areas: "column-1 column-2 column-3";

--- a/assets/header.css
+++ b/assets/header.css
@@ -23,7 +23,7 @@
 
 .header__content-inner {
   display: grid;
-  grid-template-columns: max-content 1fr max-content;
+  grid-template-columns: var(--header-grid-template-columns);
   gap: 0px 8px;
   grid-template-areas:
     "column-2 column-1 column-3";

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -121,7 +121,7 @@
             </div>
           {%- endif -%}
       {% when "app" %}
-        {% include "app" %}
+        {% render "app", block: block, section: section %}
       {%- endcase -%}
     {%- endfor -%}
   </nav>

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -20,6 +20,7 @@
 {%- assign snapchat               = settings.social_snapchat_link -%}
 {%- assign youtube                = settings.social_youtube_link -%}
 {%- assign vimeo                  = settings.social_vimeo_link -%}
+{%- assign app                    = section.blocks | where: "type", "app" | first -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -120,8 +121,6 @@
               </ul>
             </div>
           {%- endif -%}
-      {% when "app" %}
-        {% render "app", block: block, section: section %}
       {%- endcase -%}
     {%- endfor -%}
   </nav>
@@ -129,8 +128,14 @@
 
 {% comment %} Payments and social component {% endcomment %}
 {%- capture footer_icons -%}
-  {%- if facebook != blank or instagram != blank or twitter != blank or linkedin != blank or pinterest != blank or tiktok != blank or tumblr != blank or snapchat != blank or youtube != blank or vimeo != blank or payment_methods.size > 0-%}
+  {%- if facebook != blank or instagram != blank or twitter != blank or linkedin != blank or pinterest != blank or tiktok != blank or tumblr != blank or snapchat != blank or youtube != blank or vimeo != blank or payment_methods.size > 0 or app != blank -%}
     <div class="footer__icons">
+      {%- if app %}
+        <div class="footer-app">
+          {% render 'app', block: app, section: section %}
+        </div>
+      {%- endif -%}
+
       {%- if facebook != blank or instagram != blank or twitter != blank or linkedin != blank or pinterest != blank or tiktok != blank or tumblr != blank or snapchat != blank or youtube != blank or vimeo != blank -%}
         <div class="footer__social">
           {%- render "socials", settings: settings -%}
@@ -142,6 +147,7 @@
           {%- render "payments", payments: payment_methods -%}
         </div>
       {%- endif -%}
+
     </div>
   {%- endif -%}
 {%- endcapture -%}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -120,6 +120,8 @@
               </ul>
             </div>
           {%- endif -%}
+      {% when "app" %}
+        {% include "app" %}
       {%- endcase -%}
     {%- endfor -%}
   </nav>
@@ -406,6 +408,9 @@
             "default": "left"
           }
         ]
+      },
+      {
+        "type": "@app"
       }
     ]
   }

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -121,7 +121,7 @@
             </div>
           {%- endif -%}
       {% when "app" %}
-        {% include "@app" %}
+        {% include "app" %}
       {%- endcase -%}
     {%- endfor -%}
   </nav>

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -121,7 +121,7 @@
             </div>
           {%- endif -%}
       {% when "app" %}
-        {% include "app" %}
+        {% include "@app" %}
       {%- endcase -%}
     {%- endfor -%}
   </nav>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -26,7 +26,7 @@
 {%- assign snapchat              = settings.social_snapchat_link -%}
 {%- assign youtube               = settings.social_youtube_link -%}
 {%- assign vimeo                 = settings.social_vimeo_link -%}
-{%- assign app = section.blocks | where: "type", "app" | first -%}
+{%- assign app                   = section.blocks | where: "type", "app" | first -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -250,13 +250,11 @@
 
             {%- endfor -%}
 
-
             {%- if app -%}
               <div class="header-app">
                 {% render 'app', block: app, section: section, size: "mobile" %}
               </div>
             {%- endif -%}
-
           </ul>
 
           {{- social_icons -}}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -296,7 +296,7 @@
     {%- for block in section.blocks -%}
       {%- case block.type -%}
         {% when 'app' %}
-          {% include '@app' %}
+          {% include 'app' %}
       {%- endcase -%}
     {%- endfor -%}
   </div>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -26,6 +26,7 @@
 {%- assign snapchat              = settings.social_snapchat_link -%}
 {%- assign youtube               = settings.social_youtube_link -%}
 {%- assign vimeo                 = settings.social_vimeo_link -%}
+{%- assign app = section.blocks | where: "type", "app" | first -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -248,6 +249,14 @@
               {%- endif -%}
 
             {%- endfor -%}
+
+
+            {%- if app -%}
+              <div class="header-app">
+                {% render 'app', block: app, section: section, size: "mobile" %}
+              </div>
+            {%- endif -%}
+
           </ul>
 
           {{- social_icons -}}
@@ -282,6 +291,12 @@
 {% comment %} Right side buttons component {% endcomment %}
 {%- capture header_links -%}
   <div class="header__links{% if show_search %} header__links--with-search{% endif %}{% if show_mini_cart %} header__links--with-cart{%- endif -%}">
+    {%- if app -%}
+      <div class="header-app">
+        {% render 'app', block: app, section: section, size: "desktop" %}
+      </div>
+    {%- endif -%}
+
     {%- if show_search -%}
       {{- header_search -}}
     {%- endif -%}
@@ -292,13 +307,6 @@
         <i class="fa-regular fa-spinner-third fa-spin"></i>
       </div>
     {%- endif -%}
-
-    {%- for block in section.blocks -%}
-      {%- case block.type -%}
-        {% when 'app' %}
-          {% render 'app', block: block, section: section %}
-      {%- endcase -%}
-    {%- endfor -%}
   </div>
 {%- endcapture -%}
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -104,6 +104,12 @@
     --menu-right: 0;
     --menu-max-height: none;
   {%- endif -%}
+
+  {%- if section.blocks.size > 0 -%}
+    --header-grid-template-columns: max-content 1fr max-content repeat({{ section.blocks.size }}, max-content);
+  {%- else %}
+    --header-grid-template-columns: max-content 1fr max-content;
+  {%- endif -%}
 {%- endcapture -%}
 
 {%- render 'variables-mini-cart', color_palette: color_palette, settings: settings -%}
@@ -295,6 +301,16 @@
   </div>
 {%- endcapture -%}
 
+{% comment %} Apps component {% endcomment %}
+{%- capture apps -%}
+  {%- for block in section.blocks -%}
+    {%- case block.type -%}
+      {% when 'app' %}
+        {% include 'app' %}
+    {%- endcase -%}
+  {%- endfor -%}
+{%- endcapture -%}
+
 <div
   class="header__inner{% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if menu_position == 'center-left' %} header-logo-centered{%- endif -%}{% if menu_position == 'left-below' and menu != blank %} header-menu-bottom{%- endif -%}"
   style="{{- variables | escape -}}"
@@ -309,6 +325,8 @@
         </div>
 
         {{- header_menu -}}
+
+        {{- apps -}}
 
         {{- header_links -}}
 
@@ -554,6 +572,11 @@
           }
         ],
         "default": "medium"
+      }
+    ],
+    "blocks": [
+      {
+        "type": "@app"
       }
     ]
   }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -104,12 +104,6 @@
     --menu-right: 0;
     --menu-max-height: none;
   {%- endif -%}
-
-  {%- if section.blocks.size > 0 -%}
-    --header-grid-template-columns: max-content 1fr max-content repeat({{ section.blocks.size }}, max-content);
-  {%- else %}
-    --header-grid-template-columns: max-content 1fr max-content;
-  {%- endif -%}
 {%- endcapture -%}
 
 {%- render 'variables-mini-cart', color_palette: color_palette, settings: settings -%}
@@ -298,17 +292,14 @@
         <i class="fa-regular fa-spinner-third fa-spin"></i>
       </div>
     {%- endif -%}
-  </div>
-{%- endcapture -%}
 
-{% comment %} Apps component {% endcomment %}
-{%- capture apps -%}
-  {%- for block in section.blocks -%}
-    {%- case block.type -%}
-      {% when 'app' %}
-        {% include '@app' %}
-    {%- endcase -%}
-  {%- endfor -%}
+    {%- for block in section.blocks -%}
+      {%- case block.type -%}
+        {% when 'app' %}
+          {% include '@app' %}
+      {%- endcase -%}
+    {%- endfor -%}
+  </div>
 {%- endcapture -%}
 
 <div
@@ -325,8 +316,6 @@
         </div>
 
         {{- header_menu -}}
-
-        {{- apps -}}
 
         {{- header_links -}}
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -306,7 +306,7 @@
   {%- for block in section.blocks -%}
     {%- case block.type -%}
       {% when 'app' %}
-        {% include 'app' %}
+        {% include '@app' %}
     {%- endcase -%}
   {%- endfor -%}
 {%- endcapture -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -296,7 +296,7 @@
     {%- for block in section.blocks -%}
       {%- case block.type -%}
         {% when 'app' %}
-          {% include 'app' %}
+          {% render 'app', block: block, section: section %}
       {%- endcase -%}
     {%- endfor -%}
   </div>

--- a/snippets/app.liquid
+++ b/snippets/app.liquid
@@ -1,1 +1,0 @@
-{{ block.settings.app | render_theme_app: block_settings: block.settings, section_settings: section.settings }}

--- a/snippets/app.liquid
+++ b/snippets/app.liquid
@@ -1,0 +1,1 @@
+{{ block.settings.app | render_theme_app: block_settings: block.settings, section_settings: section.settings }}


### PR DESCRIPTION
Similarly to https://github.com/booqable/kylie-theme/pull/116, this adds support for app blocks to the header and the footer section.

Should not get merged until support for this has landed in the main app.