### PR TITLE
Aligning price vertically

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -181,12 +181,8 @@ bq-product-availability[visible="true"] {
   border-bottom: 0;
 }
 
-.classic-design .product-card__meta,
-.classic-design .product-card__price-info {
-  align-items: center;
-}
-
 .classic-design .product-card__meta {
+  align-items: center;
   padding-bottom: 8px;
   padding-left: 8px;
   padding-right: 8px;


### PR DESCRIPTION
The PR's goal is to align vertically the `price` in product card when product's description is of various heights and option `Element design` is set to `Classic`

Before:
![Google Chrome_2024-03-01 13-30-33@2x](https://github.com/booqable/tough-theme/assets/40244261/510132ed-a0f4-4c52-abe1-9ed05c10e59f)

After:
![Arc_2024-03-01 15-08-16@2x](https://github.com/booqable/tough-theme/assets/40244261/9c934b2b-a771-4cff-92be-f73b214a20b4)
