### PR TITLE
Improve logo quality on high resolution screens

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -67,8 +67,7 @@
     {%- render 'image',
         image: logo,
         class: 'footer__logo-image',
-        custom_width: '170',
-        custom_size: '340px',
+        custom_width: '340',
         custom_alt: shop.name,
         keep_type: true
     -%}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -68,8 +68,9 @@
         image: logo,
         class: 'footer__logo-image',
         custom_width: '170',
-        custom_size: '170px',
-        custom_alt: shop.name
+        custom_size: '340px',
+        custom_alt: shop.name,
+        keep_type: true
     -%}
   {%- elsif custom_title != blank -%}
     <h2 class="footer__logo-text">{{- custom_title -}}</h2>

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -116,7 +116,7 @@
         image: logo,
         class: 'header__logo-image',
         custom_width: '200',
-        custom_size: '200px',
+        custom_size: '400px',
         custom_alt: shop.name,
         keep_type: true
     -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -115,8 +115,7 @@
     {%- render 'image',
         image: logo,
         class: 'header__logo-image',
-        custom_width: '200',
-        custom_size: '400px',
+        custom_width: '400',
         custom_alt: shop.name,
         keep_type: true
     -%}


### PR DESCRIPTION
Increase the size we resize logo to in order to get better rendering on high-resolution (retina screens). Previously we rendered a 200px wide logo in the width of 200px, now that is increased to 400px wide image within 200px space, which looks better.

The difference is hard to notice but customers are complaining.

**Before**
<img width="801" alt="Screenshot 2024-03-07 at 11 21 21" src="https://github.com/booqable/tough-theme/assets/690113/22b3cc47-09c4-4fdb-8189-36209c87c67e">



**After**
<img width="786" alt="Screenshot 2024-03-07 at 11 21 03" src="https://github.com/booqable/tough-theme/assets/690113/0aaf10ac-53d9-4451-9425-eba9e6a46d07">
