### PR TITLE
Removed auto-adding prefixes to emails and phone numbers

### DIFF
--- a/assets/header.js
+++ b/assets/header.js
@@ -4,9 +4,7 @@ class Header {
 
     this.selector = {
       body: "body",
-      link: "a",
       bar: ".top-bar",
-      barBlock: ".top-bar__text",
       view: ".preview-bar__container",
       headerNav: ".header__nav-wrapper",
       menu: ".menu",
@@ -52,8 +50,6 @@ class Header {
     }
 
     this.attr = {
-      href: "href",
-      class: "class",
       style: "style"
     }
 
@@ -79,7 +75,6 @@ class Header {
     this.body = document.querySelector(this.selector.body);
     this.preview = document.querySelector(this.selector.view);
     this.bar = this.block.querySelector(this.selector.bar);
-    this.barBlocks = this.block.querySelectorAll(this.selector.barBlock);
     this.menu = this.block.querySelector(this.selector.menu);
     this.menuBottom = this.block.querySelector(this.selector.menuBottom);
     this.menuItem = this.menu?.querySelector(this.selector.menuItem);
@@ -98,7 +93,6 @@ class Header {
     this.headerHeight();
     this.menuPosition();
     this.hoverClose();
-    this.setEmailPhone();
     this.searchAutoFill();
 
     document.addEventListener("click", this.menuOverflow.bind(this));
@@ -284,36 +278,6 @@ class Header {
     this.block.classList.remove(this.classes.opened);
     window.scrollTo(0, 0);
     this.block.removeAttribute(this.attr.style);
-  }
-
-  // convert links to allow users to send emails and call phone numbers
-  setEmailPhone() {
-    if (!this.barBlocks.length) return false;
-
-    const keepOnly = /[^a-zA-Z0-9,\-.?!@+]/g,
-          specChars = /[\()\-\s]/g,
-          phoneRegex = /(?:[-+() ]*\d){10,13}/gm,
-          emailRegex = /(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-
-    this.barBlocks.forEach(block => {
-      const links = block.querySelectorAll(this.selector.link);
-
-      if (!links.length) return false;
-
-      links.forEach(link => {
-        let href = link.getAttribute(this.attr.href);
-        const match = href.match(phoneRegex) || href.match(emailRegex);
-
-        if (match?.length) {
-          href = match[0].replace(keepOnly, '');
-
-          if (href.match(phoneRegex)) href = `tel:${href.replaceAll(specChars, '')}`;
-          if (href.match(emailRegex)) href = `mailto:${href}`;
-
-          link.setAttribute(this.attr.href, href);
-        }
-      })
-    })
   }
 
   // set focus to the input field when opening the search popup

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -8,7 +8,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>CONSTRUCT</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 0100\">+1 555 0100</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15550100\">+1 555 0100</a>",
             "color_palette": "three",
             "icon": "phone",
             "padding_top": "medium",
@@ -142,7 +142,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>ROMANCE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 0100\">+1 555 0100</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15550100\">+1 555 0100</a>",
             "color_palette": "three",
             "icon": "phone",
             "padding_top": "medium",
@@ -276,7 +276,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "Get 15% off with code <b>VOGUE</b> at checkout",
-            "bar_text": "Call Us 24/7 <a href=\"+1 555 0100\">+1 555 0100</a>",
+            "bar_text": "Call Us 24/7 <a href=\"tel:+15550100\">+1 555 0100</a>",
             "color_palette": "three",
             "icon": "phone",
             "padding_top": "medium",
@@ -436,7 +436,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>RADICAL</b> at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 010 0100\">+1 555 010 0100</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel::+15550100100\">+1 555 010 0100</a></p>",
             "color_palette": "three",
             "icon": "empty",
             "padding_top": "medium",
@@ -576,7 +576,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Book 4 bikes and get 20% off</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 010 0100\">+1 555 010 0100</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15550100100\">+1 555 010 0100</a></p>",
             "color_palette": "three",
             "icon": "phone",
             "padding_top": "medium",
@@ -716,7 +716,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>CELEBRATE</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a></p>",
             "color_palette": "three",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -997,7 +997,7 @@
           "settings": {
             "bar_menu": null,
             "bar_message": "<p>Get 15% off with code&nbsp;<b>COASTAL</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 555 8549\"><b>+1 555 555 8549</b></a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15555558549\"><b>+1 555 555 8549</b></a></p>",
             "color_palette": "three",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1137,7 +1137,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>UTILITY</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 555 8549\"><b>+1 555 555 8549</b></a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15555558549\"><b>+1 555 555 8549</b></a></p>",
             "color_palette": "two",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1277,7 +1277,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>CHIC</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\"><b>+1 555 302 8549</b></a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\"><b>+1 555 302 8549</b></a></p>",
             "color_palette": "three",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1417,7 +1417,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>WAVERUNNER</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a></p>",
             "color_palette": "three",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1557,7 +1557,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code&nbsp;<b>CONNECT</b>&nbsp;at checkout</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\"><b>+1 555 302 8549</b></a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\"><b>+1 555 302 8549</b></a></p>",
             "color_palette": "one",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1697,7 +1697,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Free shipping from €50</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a></p>",
             "color_palette": "two",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -1831,7 +1831,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code <b>MOVE</b> at checkout.</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a></p>",
             "color_palette": "one",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -2110,7 +2110,7 @@
           "block_order": [],
           "settings": {
             "bar_message": "<p>Get 15% off with code <b>AROUND</b>&nbsp;at checkout.</p>",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 302 8549\">+1 555 302 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15553028549\">+1 555 302 8549</a></p>",
             "color_palette": "two",
             "icon": "phone",
             "padding_bottom": "medium",
@@ -2253,7 +2253,7 @@
             "padding_bottom_mobile": "medium",
             "show_bar": true,
             "icon": "phone",
-            "bar_text": "<p>Call Us 24/7 <a href=\"+1 555 555 8549\">+1 555 555 8549</a></p>",
+            "bar_text": "<p>Call Us 24/7 <a href=\"tel:+15555558549\">+1 555 555 8549</a></p>",
             "padding_bottom": "medium",
             "padding_top_mobile": "medium",
             "bar_message": "<p>Get 15% off with code <b>APEX</b> at checkout.</p>",


### PR DESCRIPTION
The customer reported that on the Topbar section in the theme builder, the option to add WhatsApp chat through a URL (wa.me/34611111111) doesn't work. It will only offer the option to call.
However, when this link is anywhere else embedded in a button, it does work.

So the PR's goal is to remove the feature that automatically finds and adds prefixes `mailto:` and `tel:` to email addresses and phone numbers accordingly from the Topbar section

![Arc_2024-03-19 18-44-59@2x](https://github.com/booqable/tough-theme/assets/40244261/02b52940-a3a7-4ad3-b1fb-44dd0a48a2b6)
