### PR TITLE
Disable carousel on mobile if `Show products as carousel` option is not chosen

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -478,33 +478,6 @@
     bottom: 33px;
   }
 
-  .carousel__destroy .carousel__wrapper {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
-    gap: 24px;
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    scroll-padding: 0;
-  }
-
-  .carousel__destroy .carousel__inner {
-    padding: 0;
-  }
-
-  .carousel__destroy .carousel__item {
-    min-width: 100%;
-  }
-
-  .carousel__destroy .carousel__item:last-child .carousel__inner {
-    padding-right: 0;
-  }
-
-  .carousel__destroy .carousel__navigation,
-  .carousel__destroy .carousel__pagination {
-    display: none;
-  }
-
   .carousel-with-date-picker.carousel__edges .carousel__navigation {
     bottom: calc(33px + var(--date-picker-block-height, 0px));
   }
@@ -548,10 +521,6 @@
   .carousel__full-width .carousel__item:last-child .carousel__inner,
   .carousel__full-width .carousel__inner {
     padding: 0;
-  }
-
-  .carousel__destroy .carousel__item {
-    min-width: 100%;
   }
 }
 

--- a/assets/products.css
+++ b/assets/products.css
@@ -6,8 +6,13 @@
   padding-bottom: var(--padding-bottom-mobile, 40px);
 }
 
-.products__list {
-  display: flex;
+.products__list:not(.carousel) {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }
 
 .palette-one.products__wrapper {

--- a/assets/products.css
+++ b/assets/products.css
@@ -9,7 +9,7 @@
 .products__list:not(.carousel) {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
-  gap: 24px;
+  gap: 16px;
   margin: 0;
   padding: 0;
   width: 100%;
@@ -29,6 +29,12 @@
 
 .classic-design .products__wrapper {
   text-align: center;
+}
+
+@media (min-width: 992px) {
+  .products__list:not(.carousel) {
+    gap: 24px;
+  }
 }
 
 @media (min-width: 1200px) {

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -18,7 +18,7 @@
   {%- assign show_excerpt          = section.settings.show_excerpt -%}
   {%- assign image_placeholder     = settings.image_placeholder -%}
   {%- assign is_focal              = settings.use_focal_images -%}
-  {%- assign items_limit           = 8 -%}
+  {%- assign items_limit           = 12 -%}
 
   {%- if collection != blank -%}
     {%- assign items = collection.items -%}
@@ -340,7 +340,7 @@
         "default": "medium"
       }
     ],
-    "max_blocks": 8,
+    "max_blocks": 12,
     "blocks": [
       {
         "type": "product",

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -18,6 +18,7 @@
   {%- assign show_excerpt          = section.settings.show_excerpt -%}
   {%- assign image_placeholder     = settings.image_placeholder -%}
   {%- assign is_focal              = settings.use_focal_images -%}
+  {%- assign items_limit           = 8 -%}
 
   {%- if collection != blank -%}
     {%- assign items = collection.items -%}
@@ -29,7 +30,7 @@
 
   {%- assign carousel = false -%}
 
-  {%- if blocks.size > 1 or collection.items_count > 1 -%}
+  {%- if blocks.size > 1 and show_carousel or collection.items_count > 1 and show_carousel -%}
     {{ "carousel.css" | asset_url | stylesheet_tag }}
 
     {%- assign carousel = true -%}
@@ -88,13 +89,13 @@
     style="{{- variables | escape -}}"
   >
     <div class="products__container container">
-      <div class="products__list{% if carousel %} carousel carousel__pause{% if show_pagination or show_navigation %} carousel--controls{% endif %}{% endif %}{% unless show_carousel %} carousel__destroy{%- endunless -%}"{% if carousel %} aria-role="Gallery"{% endif %}>
+      <div class="products__list{% if carousel %} carousel carousel__pause{% if show_pagination or show_navigation %} carousel--controls{% endif %}{%- endif -%}"{% if carousel %} aria-role="Gallery"{% endif %}>
         {%- if carousel -%}
           <input class="carousel__timer" type="hidden" name="hidden" value="{{- timer -}}" aria-hidden="true">
           <div class="carousel__wrapper">
         {%- endif -%}
 
-            {%- for item in items limit: 8 -%}
+            {%- for item in items limit: items_limit -%}
               {% case items_type %}
                 {% when "blocks" %}
                   {% assign product = item.settings.product %}
@@ -136,7 +137,7 @@
 
           {%- if show_pagination -%}
             <div class="carousel__pagination hidden" aria-role="Carousel pagination">
-              {%- for item in items limit: 8 -%}
+              {%- for item in items limit: items_limit -%}
                 {%- assign first = forloop.first -%}
                 {%- assign index = forloop.index -%}
 


### PR DESCRIPTION
Currently, the Product section has 2 different layouts for mobile and desktop if the `Show products as carousel` option is not chosen

So the purpose of this PR is to use only 1 layout for both desktop and mobile

Before:

![Preview_2024-03-28 17-12-08@2x](https://github.com/booqable/tough-theme/assets/40244261/82b7847d-d36d-44fb-b16a-4b585f469781)


After:

![Preview_2024-03-28 17-13-08@2x](https://github.com/booqable/tough-theme/assets/40244261/a2db826f-be67-4a2c-a870-cd62a9d6e2bb)
