### PR TITLE
`See all` button URL correction

### DIFF
--- a/templates/around/index.json
+++ b/templates/around/index.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "button_label": "",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "",
         "padding_bottom": "none",

--- a/templates/chic/index.json
+++ b/templates/chic/index.json
@@ -8,7 +8,7 @@
       "settings": {
         "bg_text": "",
         "button_label": "",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "<p>What's chic right now?</p>",
         "padding_bottom": "small",

--- a/templates/construct/index.json
+++ b/templates/construct/index.json
@@ -193,7 +193,7 @@
       "block_order": [],
       "settings": {
         "button_label": "View all",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "Our most rented products",
         "padding_bottom": "small",

--- a/templates/construct/product.json
+++ b/templates/construct/product.json
@@ -40,7 +40,7 @@
       "block_order": [],
       "settings": {
         "button_label": "View all",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "padding_bottom": "small",

--- a/templates/product.json
+++ b/templates/product.json
@@ -40,7 +40,7 @@
       "block_order": [],
       "settings": {
         "button_label": "View all",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "padding_bottom": "small",

--- a/templates/radical/index.json
+++ b/templates/radical/index.json
@@ -6,7 +6,7 @@
       "blocks": {},
       "block_order": [],
       "settings": {
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "padding_top": "medium",
         "button_label": "See all",
         "padding_bottom_mobile": "none",

--- a/templates/romance/index.json
+++ b/templates/romance/index.json
@@ -145,7 +145,7 @@
       "block_order": [],
       "settings": {
         "button_label": "See all",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "",
         "padding_bottom": "",

--- a/templates/utility/index.json
+++ b/templates/utility/index.json
@@ -77,7 +77,7 @@
       "settings": {
         "bg_text": "Safe driving",
         "button_label": "",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "",
         "padding_bottom": "small",

--- a/templates/vogue/index.json
+++ b/templates/vogue/index.json
@@ -145,7 +145,7 @@
       "block_order": [],
       "settings": {
         "button_label": "See all",
-        "button_url": "/collections/all",
+        "button_url": "booqable://product/",
         "color_palette": "one",
         "description": "",
         "padding_bottom": "none",


### PR DESCRIPTION
If clicking `See all` button next to the `Products` title while in the theme editor on a fresh theme installation there will be the preview that loads Booqable's interface

So this PR's goal is to replace all broken URLs of `See all` buttons across all templates

<img width="1679" alt="image" src="https://github.com/booqable/tough-theme/assets/40244261/5d575c89-f4aa-4c00-908b-d411016ea0b3">
<img width="1679" alt="image1" src="https://github.com/booqable/tough-theme/assets/40244261/117e0161-aa7b-4d61-80b4-ed52f5a303ef">

