### PR TITLE
Fix the issue when adding several accordions on the same page

### DIFF
--- a/sections/accordion.liquid
+++ b/sections/accordion.liquid
@@ -68,7 +68,8 @@
     <div class="accordion__container container">
       {%- render 'accordion-block',
           blocks: blocks,
-          behavior: behavior
+          behavior: behavior,
+          section_id: section.key
       -%}
     </div>
 

--- a/snippets/accordion-block.liquid
+++ b/snippets/accordion-block.liquid
@@ -3,13 +3,15 @@
   This snippet is used for rendering the accordion
 
   blocks - { object } *required,
-  behavior - "string" *required
+  behavior - "string" *required,
+  section_id: - "string" *required
 
   Usage:
 
   {%- render 'accordion-block',
       blocks: blocks,
-      behavior: your_id
+      behavior: your_id,
+      section_id: your_id
   -%}
 
 {% endcomment %}
@@ -20,31 +22,17 @@
       {%- assign heading = block.settings.heading -%}
       {%- assign content = block.settings.content -%}
 
-      {% case block.type %}
-        {% when "details" %}
-          {%- assign heading = "Details" -%}
-          {%- assign content = block.settings.details -%}
-
-        {% when "shipping" %}
-          {%- assign heading = "Shipping" -%}
-          {%- assign content = block.settings.shipping -%}
-
-        {% when "returns" %}
-          {%- assign heading = "Returns" -%}
-          {%- assign content = block.settings.returns -%}
-      {% endcase %}
-
       <li class="accordion-block__item" id="{{- block.id -}}">
         {%- if heading != blank -%}
           <input
             {% if behavior == "single" %}type="radio"{% else %}type="checkbox"{% endif %}
             class="accordion-block__trigger"
-            id="accordion-block-{{- block.id -}}"
+            id="{{- section_id -}}-{{- block.id -}}"
             name="accordion trigger"
           />
 
           <h3 class="accordion-block__heading">
-            <label class="accordion-block__label" for="accordion-block-{{- block.id -}}">
+            <label class="accordion-block__label" for="{{- section_id -}}-{{- block.id -}}">
               {{- heading -}}
               {%- render 'icon-arrow-right' -%}
             </label>


### PR DESCRIPTION
When adding several accordion sections on a page, only the first section works correctly, the other accordions won't drop down. It happens because of duplication of the same IDs

So the PR's goal is to add section ID to accordion items and clean up the code.

