### PR TITLE
Fix image URL check in liquid templates

### DIFF
--- a/sections/call-to-action.liquid
+++ b/sections/call-to-action.liquid
@@ -95,7 +95,7 @@
     {%- endif -%}
   </div>
 
-  {%- if image != blank -%}
+  {%- if image.url != blank -%}
     <div class="cta__image-wrapper">
       {%- render 'image',
         image: image,

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -119,7 +119,7 @@
     </div>
   {%- endif -%}
 
-  {%- if image != blank -%}
+  {%- if image.url != blank -%}
     <div class="hero__vision{% if show_datepicker %} hero__vision--indent{%- endif -%}">
       <div class="hero__vision-wrapper">
           {%- render 'image',

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -84,7 +84,7 @@
     </div>
   {%- endif -%}
 
-  {%- if image != blank -%}
+  {%- if image.url != blank -%}
     <div class="hero__vision{% if show_datepicker %} hero__vision--indent{%- endif -%}">
       <div class="hero__vision-wrapper">
           {%- render 'image',

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -396,7 +396,7 @@
                       </div>
 
                     {%- elsif image != blank or image_mobile != blank -%}
-                      {%- if image != blank -%}
+                      {%- if image.url != blank -%}
                         <div class="images__vision-wrapper{% if image_mobile != blank %} images__vision-wrapper--desktop{% endif %}{% if show_overlay %} images__vision-wrapper--overlay{%- endif -%}">
                           {%- render 'image',
                             image: image,
@@ -407,7 +407,7 @@
                         </div>
                       {%- endif -%}
 
-                      {%- if image_mobile != blank -%}
+                      {%- if image_mobile.url != blank -%}
                         <div class="images__vision-wrapper images__vision-wrapper--mobile{% if show_overlay %} images__vision-wrapper--overlay{%- endif -%}">
                           {%- render 'image',
                             image: image_mobile,

--- a/sections/locations.liquid
+++ b/sections/locations.liquid
@@ -154,7 +154,7 @@
             {%- if address != blank or city != blank or zipcode != blank -%}
               <div id="map-{{- block.id -}}" class="map" data-address="{{- address -}}, {{ city }}, {{ zipcode }}"></div>
 
-              {%- if icon != blank -%}
+              {%- if icon.url != blank -%}
                 <div class="map-icon" style="transform: translate(0, -100%); position: relative; z-index: -1;">
                   {%- render 'image',
                     image: icon,

--- a/sections/mosaic.liquid
+++ b/sections/mosaic.liquid
@@ -86,7 +86,7 @@
 
           <div class="mosaic__item" id="{{- block.id -}}">
             <div class="mosaic__item-col{% if image == blank %} no-image{% else %} mosaic__item-col--image{%- endif -%}">
-              {%- if image != blank -%}
+              {%- if image.url != blank -%}
                 {%- render 'image',
                   image: image,
                   loading: 'lazy',

--- a/sections/numbered-blocks.liquid
+++ b/sections/numbered-blocks.liquid
@@ -139,7 +139,7 @@
               </div>
             </div>
 
-            {%- if image != blank -%}
+            {%- if image.url != blank -%}
               <div class="numbered-blocks__item-col">
                 {%- render 'image',
                   image: image,

--- a/sections/split-screen.liquid
+++ b/sections/split-screen.liquid
@@ -118,7 +118,7 @@
 <div class="split-screen__wrapper split-screen__wrapper--{{- layout -}}{% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if show_datepicker and datepicker_position == "bottom" %}{% if image != blank %} split-screen__wrapper--with-image{% endif %} section-with-date-picker{%- endif -%}" style="{{- variables | escape -}}">
   <div class="split-screen__container container{% if padding_top != blank or padding_top_mobile != blank %} split-screen__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} split-screen__container--padding-bottom{%- endif -%}">
     <div class="split-screen__columns">
-      {%- if image != blank -%}
+      {%- if image.url != blank -%}
         <div class="split-screen__col{% if image != blank %} split-screen__col--image{%- endif -%}">
           {%- render 'image',
             image: image,

--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -163,7 +163,7 @@
                         </div>
                       {%- endif -%}
 
-                      {%- if image != blank -%}
+                      {%- if image.url != blank -%}
                         <div class="testimonials__col">
                           <div class="testimonials__image-wrapper">
                             {%- render 'image',

--- a/sections/text-with-image.liquid
+++ b/sections/text-with-image.liquid
@@ -172,7 +172,7 @@
         {%- endif -%}
       </div>
 
-      {%- if image != blank -%}
+      {%- if image.url != blank -%}
         <div class="text-image__col">
           <div class="text-image__holder">
             <div class="text-image__image-wrapper">


### PR DESCRIPTION
The issue we discussed on standups when the `Image resizer` is logging too many errors. Zoran said [this](https://github.com/booqable/tough-theme/pull/186) fix cut errors in half. So Zoran and I discussed this issue and decided that consequently, we could eliminate some more errors by checking the image URL in all conditions in all liquid files before rendering the image

So the PR's purpose is to add the `.url` key into every scenario involving image rendering where it is currently missing