### PR TITLE
Hide session pages if accounts are disabled

### DIFF
--- a/templates/activate-account.json
+++ b/templates/activate-account.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["activate-account"]
+  "order": ["activate-account"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/construct/activate-account.json
+++ b/templates/construct/activate-account.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["activate-account"]
+  "order": ["activate-account"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/construct/edit-password.json
+++ b/templates/construct/edit-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["edit-password-form"]
+  "order": ["edit-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/construct/login.json
+++ b/templates/construct/login.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["login-form"]
+  "order": ["login-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/construct/register.json
+++ b/templates/construct/register.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["register-form"]
+  "order": ["register-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/construct/reset-password.json
+++ b/templates/construct/reset-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["reset-password-form"]
+  "order": ["reset-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/edit-password.json
+++ b/templates/edit-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["edit-password-form"]
+  "order": ["edit-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/login.json
+++ b/templates/login.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["login-form"]
+  "order": ["login-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/register.json
+++ b/templates/register.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["register-form"]
+  "order": ["register-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/reset-password.json
+++ b/templates/reset-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["reset-password-form"]
+  "order": ["reset-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/romance/activate-account.json
+++ b/templates/romance/activate-account.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["activate-account"]
+  "order": ["activate-account"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/romance/edit-password.json
+++ b/templates/romance/edit-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["edit-password-form"]
+  "order": ["edit-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/romance/login.json
+++ b/templates/romance/login.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["login-form"]
+  "order": ["login-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/romance/register.json
+++ b/templates/romance/register.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["register-form"]
+  "order": ["register-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/romance/reset-password.json
+++ b/templates/romance/reset-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["reset-password-form"]
+  "order": ["reset-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/vogue/activate-account.json
+++ b/templates/vogue/activate-account.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["activate-account"]
+  "order": ["activate-account"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/vogue/edit-password.json
+++ b/templates/vogue/edit-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["edit-password-form"]
+  "order": ["edit-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/vogue/login.json
+++ b/templates/vogue/login.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["login-form"]
+  "order": ["login-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/vogue/register.json
+++ b/templates/vogue/register.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["register-form"]
+  "order": ["register-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }

--- a/templates/vogue/reset-password.json
+++ b/templates/vogue/reset-password.json
@@ -14,5 +14,8 @@
       }
     }
   },
-  "order": ["reset-password-form"]
+  "order": ["reset-password-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
 }


### PR DESCRIPTION
When accounts are disabled, account related templates throw errors in the theme editor. This PR makes sure those templates are hidden depending on the account settings.