### PR TITLE
Update logo size for mobile

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -46,6 +46,9 @@
   grid-area: column-1;
   position: relative;
   z-index: 1;
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .header__logo-text {

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -67,7 +67,7 @@
     {%- render 'image',
         image: logo,
         class: 'footer__logo-image',
-        custom_width: '340',
+        size: 'logo',
         custom_alt: shop.name,
         keep_type: true
     -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -115,7 +115,7 @@
     {%- render 'image',
         image: logo,
         class: 'header__logo-image',
-        custom_width: '400',
+        size: 'logo',
         custom_alt: shop.name,
         keep_type: true
     -%}

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -36,20 +36,22 @@
 {%- endif -%}
 
 {% comment %}
-This code ensures we load the correct image size based on its width on the screen.
-Media queries are built relative to the viewport width, so we define image size depending on expected width relative to the viewport.
+  This code ensures we load the correct image size based on its width on the screen.
+  Media queries are built relative to the viewport width, so we define image size depending on expected width relative to the viewport.
 
-For example:
-A hero image would be approximately as wide as the whole viewport, so we would use the xxl size.
-A testimonial image would be approximately as wide as half of the viewport (as it is show on the side), so we would use the l size.
+  For example:
+  A hero image would be approximately as wide as the whole viewport, so we would use the xxl size.
+  A testimonial image would be approximately as wide as half of the viewport (as it is show on the side), so we would use the l size.
 
-xs - Image is wide as 1/16 of the viewport
-s - Image is wide as 1/8 of the viewport
-m - Image is wide as 1/4 of the viewport
-l - Image is wide as half of the viewport
-xl - Image is wide as 3/4 of the viewport
-xxl - Image is as wide as the whole viewport
+  xs - Image is wide as 1/16 of the viewport
+  s - Image is wide as 1/8 of the viewport
+  m - Image is wide as 1/4 of the viewport
+  l - Image is wide as half of the viewport
+  xl - Image is wide as 3/4 of the viewport
+  xxl - Image is as wide as the whole viewport
+  logo - Image has the same size and quality on all resolutions
 {% endcomment %}
+
 {%- case size -%}
   {%- when 'xs' -%}
     {%- assign image_width = '20, 30, 48, 75, 105, 160' -%}
@@ -69,6 +71,9 @@ xxl - Image is as wide as the whole viewport
   {%- when 'xxl' -%}
     {%- assign image_width = '320, 480, 768, 1200, 1680, 2560' -%}
     {%- assign image_sizes = '(max-width: 320px) 320px, (max-width: 480px) 480px, (max-width: 768px) 768px, (max-width: 1200px) 1200px, (max-width: 1680px) 1680px, 2560px' -%}
+  {%- when 'logo' -%}
+    {%- assign image_width = '420, 640' -%}
+    {%- assign image_sizes = '(max-width: 360px) 420px, 640px' -%}
 {%- endcase -%}
 
 {%- if custom_width != blank and custom_size != blank -%}


### PR DESCRIPTION
I observed a discrepancy regarding the logo's dimensions on mobile devices, specifically within the Header and Footer. 

Delving deeper into the matter revealed that the `custom_size` attribute was missing when rendering the logo image snippet. It appears that Filip, in a recent update had been tried to increase the logo quality (visible in this [PR](https://github.com/booqable/tough-theme/pull/193)), removed this attribute, leaving only the `custom_width`. 
However, these attributes are designed to function collaboratively. 

As a result of this alteration, both `custom width` and `custom size` settings were disregarded, leading to the application of the default size `m`. 

In comparison, this size selection seems adequate for desktop displays but if taken into account mobile devices have a device pixel ratio of 2 or 3, rendering the logo noticeably smaller than intended on such screens.


So the goal of this PR is to add a new size for the logo that will have the same size and quality for both desktop and mobile



Before:

![2024-04-03 17 34 03](https://github.com/booqable/tough-theme/assets/40244261/1be84eec-5b11-478a-8a50-11a3b5ab6531)


After:

![2024-04-03 17 34 09](https://github.com/booqable/tough-theme/assets/40244261/7ae42880-1958-442b-89e2-4708526bfd6c)
