### PR TITLE
Fix for the carousel slides if there are less than 4

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -46,6 +46,7 @@
 .carousel__item {
   position: relative;
   min-width: var(--slide-width-mobile);
+  max-width: var(--slide-width-mobile);
   transition: all calc(var(--animation-duration, 200ms) + 200ms) var(--transition-function-ease);
   padding: 0;
   scroll-snap-align: start;
@@ -54,6 +55,7 @@
 
 .carousel__item:last-child {
   min-width: calc(var(--slide-width-mobile) + 16px);
+  max-width: calc(var(--slide-width-mobile) + 16px);
 }
 
 .carousel__item:last-child .carousel__inner {
@@ -147,6 +149,7 @@
 
 .carousel__full-width .carousel__item:last-child {
   min-width: var(--slide-width-mobile);
+  max-width: var(--slide-width-mobile);
 }
 
 .carousel__full-width .carousel__inner {
@@ -155,6 +158,7 @@
 
 .carousel__edges .carousel__item:last-child {
   min-width: var(--slide-width-mobile);
+  max-width: var(--slide-width-mobile);
 }
 
 .carousel__edges .carousel__item:not(:first-child) {
@@ -433,10 +437,12 @@
 
   .carousel__item {
     min-width: var(--slide-width);
+    max-width: var(--slide-width);
   }
 
   .carousel__item:last-child {
     min-width: calc(var(--slide-width) + 32px);
+    max-width: calc(var(--slide-width) + 32px);
   }
 
   .carousel__item:last-child .carousel__inner {
@@ -450,6 +456,7 @@
   .carousel__edges .carousel__item,
   .carousel__edges .carousel__item:last-child {
     min-width: var(--slide-width);
+    max-width: var(--slide-width);
   }
 
   .carousel__edges .images__text-area {
@@ -512,6 +519,7 @@
 
   .carousel__item:last-child {
     min-width: calc(var(--slide-width) - 32px);
+    max-width: calc(var(--slide-width) - 32px);
   }
 
   .carousel__item:last-child .carousel__inner {


### PR DESCRIPTION
Upon observation, I discovered that slides are capable of expanding to occupy all available space when their number is fewer than four. This flexibility, however, introduces the potential for the slides to adopt widths that are not proportional.

So this PR adds a limit to the slide width, which will allow all slides to have the same width regardless of the number of slides.

Before:
![Around_2024-04-04 11-13-12@2x](https://github.com/booqable/tough-theme/assets/40244261/6da4019b-8a79-4ae4-88b8-abe4a08e7615)


After:
![Arc_2024-04-04 12-08-24@2x](https://github.com/booqable/tough-theme/assets/40244261/1f526a8e-9eec-413c-9897-9b10564f977f)
