### PR TITLE
Fix the visibility of the Products carousel and update its styles

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -426,13 +426,13 @@
 
 @media (min-width: 992px) {
   .carousel__wrapper {
-    margin: 0 -32px;
-    width: calc(100% + 64px);
-    scroll-padding: 0 32px 0 0;
+    margin: 0 -24px;
+    width: calc(100% + 48px);
+    scroll-padding: 0 24px 0 0;
   }
 
   .carousel__inner {
-    padding: 0 0 0 32px;
+    padding: 0 0 0 24px;
   }
 
   .carousel__item {
@@ -441,16 +441,16 @@
   }
 
   .carousel__item:last-child {
-    min-width: calc(var(--slide-width) + 32px);
-    max-width: calc(var(--slide-width) + 32px);
+    min-width: calc(var(--slide-width) + 24px);
+    max-width: calc(var(--slide-width) + 24px);
   }
 
   .carousel__item:last-child .carousel__inner {
-    padding-right: 32px;
+    padding-right: 24px;
   }
 
   .carousel__full-width .carousel__inner {
-    padding-right: 32px;
+    padding-right: 24px;
   }
 
   .carousel__edges .carousel__item,
@@ -514,12 +514,12 @@
   }
 
   .carousel__inner {
-    padding: 0 32px 0 0;
+    padding: 0 24px 0 0;
   }
 
   .carousel__item:last-child {
-    min-width: calc(var(--slide-width) - 32px);
-    max-width: calc(var(--slide-width) - 32px);
+    min-width: calc(var(--slide-width) - 24px);
+    max-width: calc(var(--slide-width) - 24px);
   }
 
   .carousel__item:last-child .carousel__inner {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -3,6 +3,7 @@
   grid-template-rows: max-content 1fr;
   position: relative;
   min-width: 298px;
+  overflow: clip;
 }
 
 .product-card__vision {

--- a/assets/products.css
+++ b/assets/products.css
@@ -8,7 +8,7 @@
 
 .products__list:not(.carousel) {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(298px, 1fr));
   gap: 16px;
   margin: 0;
   padding: 0;
@@ -44,5 +44,9 @@
 
   .products__wrapper--padding-bottom {
     padding-bottom: var(--padding-bottom, 112px);
+  }
+
+  .products__list:not(.carousel) {
+    grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
   }
 }

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -19,21 +19,26 @@
   {%- assign image_placeholder     = settings.image_placeholder -%}
   {%- assign is_focal              = settings.use_focal_images -%}
   {%- assign items_limit           = 12 -%}
+  {%- assign carousel              = false -%}
 
   {%- if collection != blank -%}
     {%- assign items = collection.items -%}
     {%- assign items_type = "collection" -%}
+
+    {%- if collection.items_count > 1 and show_carousel -%}
+      {%- assign carousel = true -%}
+    {%- endif -%}
   {%- else -%}
     {%- assign items = blocks -%}
     {%- assign items_type = "blocks" -%}
+
+    {%- if blocks.size > 1 and show_carousel -%}
+      {%- assign carousel = true -%}
+    {%- endif -%}
   {%- endif -%}
 
-  {%- assign carousel = false -%}
-
-  {%- if blocks.size > 1 and show_carousel or collection.items_count > 1 and show_carousel -%}
+  {%- if carousel -%}
     {{ "carousel.css" | asset_url | stylesheet_tag }}
-
-    {%- assign carousel = true -%}
   {%- endif -%}
 
   {% comment %} CSS variables start {% endcomment %}


### PR DESCRIPTION
Currently, we're encountering challenges concerning the visibility of carousels. Initially, when a collection including few items is selected and blocks are subsequently disabled, the entire section vanishes. Moreover, in the scenario where a collection is chosen and merely a single block is enabled, the carousel fails to function despite 'Show products as carousel' feature is active.

So the PR's goal is to fix carousel visibility issues and update some its styles