### PR TITLE
Limit logo width

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -62,6 +62,7 @@
 
 .header__logo-image {
   max-height: 64px;
+  max-width: 200px;
 }
 
 .header__nav-wrapper {


### PR DESCRIPTION
The mobile menu doesn't appear when the device is held vertically in Endure template. So, the logo width should be limited to display all next-to-it icons in header on narrow screens

Before:
<img width="715" alt="imagewf" src="https://github.com/booqable/tough-theme/assets/40244261/f2690d6b-9b7b-4116-ace2-4767d68c5abb">


After:
![Arc_2024-04-15 14-48-47@2x](https://github.com/booqable/tough-theme/assets/40244261/fdeab77a-2270-40d5-822b-9d13eaeafe78)
