### PR TITLE
Fix search error in website's preview mode

### DIFF
--- a/assets/header.js
+++ b/assets/header.js
@@ -13,6 +13,7 @@ class Header {
       menuBottom: ".header-menu-bottom",
       menuOpener: "#mobile-menu-opener",
       search: ".header__search",
+      searchForm: "#search",
       searchOpener: "#search-opener",
       searchInput: ".header__search-input",
       searchReset: ".header__search-reset",
@@ -50,7 +51,8 @@ class Header {
     }
 
     this.attr = {
-      style: "style"
+      style: "style",
+      action: "action"
     }
 
     this.params = {
@@ -80,6 +82,7 @@ class Header {
     this.menuItem = this.menu?.querySelector(this.selector.menuItem);
     this.menuDrops = this.block.querySelectorAll(this.selector.menuDrop);
     this.menuOpener = this.block.querySelector(this.selector.menuOpener);
+    this.searchForm = this.block.querySelector(this.selector.searchForm);
     this.searchOpener = this.block.querySelector(this.selector.searchOpener);
     this.searchInput = this.block.querySelector(this.selector.searchInput);
     this.searchReset = this.block.querySelector(this.selector.searchReset);
@@ -95,6 +98,7 @@ class Header {
     this.hoverClose();
     this.searchAutoFill();
 
+    document.addEventListener("submit", this.searchHandleSubmit.bind(this));
     document.addEventListener("click", this.menuOverflow.bind(this));
     document.addEventListener("click", this.closeModals.bind(this));
     document.addEventListener("click", this.searchFocus.bind(this));
@@ -322,6 +326,22 @@ class Header {
     if (!query) return false;
 
     this.searchInput.value = query;
+  }
+
+  searchHandleSubmit (e) {
+    const target = e.target;
+
+    if (target !== this.searchForm) return false;
+
+    e.preventDefault();
+
+    const value = this.searchInput.value,
+          route = this.searchForm.getAttribute(this.attr.action);
+
+    this.url.href = this.url.origin + route;
+    this.url.searchParams.set(this.params.q, value);
+
+    window.location.href = this.url.href;
   }
 
   setCssVar(key, val) {


### PR DESCRIPTION
There's a problem in the Preview mode. In this mode, the search bar always shows "HTTP ERROR 404" page, even if you search for an existing product.
The problem is the URL after searching for an item.
It is redirecting to `/search?q=test` but this doesn't work with the Preview mode, it should be `/search?theme_id='here the theme id'&q'here what you're searching'`
The PR's goal is to add a lost `theme_id` parameter to URL which is required for correct search work in the Preview mode

Before:
![image (16)](https://github.com/booqable/tough-theme/assets/40244261/82019ccb-5522-4009-8fb9-bebd6595bb99)


After:
![Arc_2024-04-17 14-05-04@2x](https://github.com/booqable/tough-theme/assets/40244261/7e6b36ef-11e3-4b38-8187-c1306639fa31)
![Arc_2024-04-17 14-04-41@2x](https://github.com/booqable/tough-theme/assets/40244261/b80c5cf5-b952-4d56-98f1-73f4f5ce7e10)

