### PR TITLE
Refactor pagination styling and logic

### DIFF
--- a/assets/pagination.css
+++ b/assets/pagination.css
@@ -72,7 +72,6 @@
   color: var(--color-secondary, #4E5D78);
 }
 
-.palette-one .pagination .deco,
 .palette-one .pagination .current {
   background: var(--background-accent, #F4B841);
   color: var(--color-accent, #0B1A26);
@@ -111,7 +110,6 @@
   color: var(--color-secondary-2, #E1E4E8);
 }
 
-.palette-two .pagination .deco,
 .palette-two .pagination .current {
   background: var(--background-accent-2, #F4B841);
   color: var(--color-accent-2, #0B1A26);
@@ -150,7 +148,6 @@
   color: var(--color-secondary-3, #FFFFFF);
 }
 
-.palette-three .pagination .deco,
 .palette-three .pagination .current {
   background: var(--background-accent-3, #0B1A26);
   color: var(--color-accent-3, #FFFFFF);

--- a/snippets/pagination.liquid
+++ b/snippets/pagination.liquid
@@ -22,8 +22,9 @@
   </span>
 
   {%- for part in parts -%}
-    {%- assign title_to_page = part.title | times: 1 -%}
+    {%- assign title_to_page   = part.title | times: 1 -%}
     {%- assign current_to_page = paginate.current_page | times: 1 -%}
+    {%- assign last            = forloop.last -%}
 
     {%- if part.is_link -%}
       <span class="page">
@@ -34,9 +35,11 @@
         {{- part.title -}}
       </span>
     {%- else -%}
-      <span class="deco">
-        {{- part.title -}}
-      </span>
+      {%- unless last -%}
+        <span class="deco">
+          {{- part.title -}}
+        </span>
+      {%- endunless -%}
     {%- endif -%}
   {%- endfor -%}
 


### PR DESCRIPTION
Currently, for the pagination, the `[…]` take an accent color.
It's also not very clear why the last item is a `[…]`, it should just be the number of the last page.

So, the PRs purpose is to remove accent colors for `[...]` of the pagination and make the format like `[<] [1] [2] [3] [4] […] [27] [>]`

Before:

![Arc_2024-04-22 12-12-21@2x](https://github.com/booqable/tough-theme/assets/40244261/13a78c07-8d2c-48d0-a002-572d9975b2ec)


After:

![Arc_2024-04-22 12-11-25@2x](https://github.com/booqable/tough-theme/assets/40244261/7107384e-cd89-4b1b-8190-57c3302b5ccb)
