### PR TITLE
Weglot app responsive styles

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -84,6 +84,51 @@
   text-decoration: none;
 }
 
+.footer__app + .footer__social {
+  margin-right: 16px;
+}
+
+#section-footer .footer__app .weglot-widget__wrapper {
+  border-radius: var(--border-radius-dynamic);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-footer .footer__app .weglot-widget__wrapper .weglot-widget__label {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down {
+  top: auto;
+  bottom: calc(100% + 11px);
+  left: 50%;
+  transform: translate(-50%, 0);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-rounded);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down:before,
+#section-footer .footer__app .weglot-widget__dropdown--down:after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 0px;
+  height: 0px;
+  border-style: solid;
+  border-width: 10px 10px 0 10px;
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down:before {
+  top: calc(100% + 1px);
+}
+
+#section-footer .footer__app .weglot-widget__item {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
 .palette-one.footer__wrapper {
   color: var(--color-primary, #0B1A26);
   background: var(--background-primary, #FFFFFF);
@@ -114,6 +159,63 @@
 
 .palette-one .footer__bottom {
   border-top-color: var(--color-border, #0B1A2626);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__wrapper {
+  border-color: var(--color-border, #0B1A2626);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down {
+  border-color: var(--color-border, #0B1A2626);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:before,
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__item:hover {
+  color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__item:active {
+  color: var(--color-outline-active, #F4B841BA);
 }
 
 .palette-two.footer__wrapper {
@@ -148,6 +250,63 @@
   border-top-color: var(--color-border-2, #FFFFFF47);
 }
 
+#section-footer .palette-two .footer__app .weglot-widget__wrapper {
+  border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down {
+  border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:before,
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__item:hover {
+  color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__item:active {
+  color: var(--color-outline-2-active, #F4B841BA);
+}
+
 .palette-three.footer__wrapper {
   color: var(--color-primary-3, #0B1A26);
   background: var(--background-primary-3, #F4B841);
@@ -180,8 +339,61 @@
   border-top-color: var(--color-border-3, #0B1A2626);
 }
 
-.footer__app {
-  margin-left: var(--horizontal-padding, 16px);
+#section-footer .palette-three .footer__app .weglot-widget__wrapper {
+  border-color: var(--color-border-3, #0B1A2626);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down {
+  border-color: var(--color-border-3, #0B1A2626);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:before,
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__item:hover {
+  color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__item:active {
+  color: var(--color-outline-3-active, #0B1A26BA);
 }
 
 @media (min-width: 992px) {

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -89,7 +89,7 @@
 }
 
 #section-footer .footer__app .weglot-widget__wrapper {
-  border-radius: var(--border-radius-dynamic);
+  border-radius: var(--border-radius-dynamic, 0);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -100,8 +100,8 @@
 #section-footer .footer__app .weglot-widget__dropdown {
   left: 50%;
   transform: translate(-50%, 0);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-rounded);
+  border: 1px solid var(--color-border, #0B1A2626);
+  border-radius: var(--border-radius-rounded, 0);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -205,6 +205,7 @@
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border, #0B1A2626);
+  box-shadow: 0 0 8px var(--color-border, #0B1A2626);
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown:hover {
@@ -311,6 +312,7 @@
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border-2, #FFFFFF47);
+  box-shadow: 0 0 8px var(--color-border-2, #FFFFFF47);
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown:hover {
@@ -417,6 +419,7 @@
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border-3, #0B1A2626);
+  box-shadow: 0 0 8px var(--color-border-3, #0B1A2626);
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown:hover {

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -97,9 +97,7 @@
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-footer .footer__app .weglot-widget__dropdown--down {
-  top: auto;
-  bottom: calc(100% + 11px);
+#section-footer .footer__app .weglot-widget__dropdown {
   left: 50%;
   transform: translate(-50%, 0);
   border: 1px solid var(--color-border);
@@ -107,22 +105,46 @@
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-footer .footer__app .weglot-widget__dropdown--down:before,
-#section-footer .footer__app .weglot-widget__dropdown--down:after {
+#section-footer .footer__app .weglot-widget__dropdown--up {
+  top: auto;
+  bottom: calc(100% + 11px);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down {
+  bottom: auto;
+  top: calc(100% + 11px);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown:before,
+#section-footer .footer__app .weglot-widget__dropdown:after {
   content: "";
   position: absolute;
-  top: 100%;
   left: 50%;
   transform: translate(-50%, 0);
   width: 0px;
   height: 0px;
   border-style: solid;
-  border-width: 10px 10px 0 10px;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-footer .footer__app .weglot-widget__dropdown--down:before {
+#section-footer .footer__app .weglot-widget__dropdown--up:before,
+#section-footer .footer__app .weglot-widget__dropdown--up:after {
+  top: 100%;
+  border-width: 10px 10px 0 10px;
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--up:before {
   top: calc(100% + 1px);
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down:before,
+#section-footer .footer__app .weglot-widget__dropdown--down:after {
+  bottom: 100%;
+  border-width: 0 10px 10px 10px;
+}
+
+#section-footer .footer__app .weglot-widget__dropdown--down:before {
+  bottom: calc(100% + 1px);
 }
 
 #section-footer .footer__app .weglot-widget__item {
@@ -181,33 +203,50 @@
   color: var(--color-outline-active, #F4B841BA);
 }
 
-#section-footer .palette-one .footer__app .weglot-widget__dropdown--down {
+#section-footer .palette-one .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border, #0B1A2626);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--up:before,
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-footer .palette-one .footer__app .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown--down:before,
 #section-footer .palette-one .footer__app .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary, #FFFFFF) transparent;
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
-}
-
-#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-hover, #F4B841CC);
-}
-
-#section-footer .palette-one .footer__app .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-active, #F4B841BA);
+  border-color: transparent transparent var(--color-border, #0B1A2626) transparent;
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-hover, #F4B841CC) transparent;
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-active, #F4B841BA) transparent;
 }
 
 #section-footer .palette-one .footer__app .weglot-widget__item:hover {
@@ -270,33 +309,50 @@
   color: var(--color-outline-2-active, #F4B841BA);
 }
 
-#section-footer .palette-two .footer__app .weglot-widget__dropdown--down {
+#section-footer .palette-two .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--up:before,
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-footer .palette-two .footer__app .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown--down:before,
 #section-footer .palette-two .footer__app .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary-2, #0B1A26) transparent;
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
-}
-
-#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-2-hover, #F4B841CC);
-}
-
-#section-footer .palette-two .footer__app .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-2-active, #F4B841BA);
+  border-color: transparent transparent var(--color-border-2, #FFFFFF47) transparent;
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-2-hover, #F4B841CC) transparent;
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-2-active, #F4B841BA) transparent;
 }
 
 #section-footer .palette-two .footer__app .weglot-widget__item:hover {
@@ -359,33 +415,50 @@
   color: var(--color-outline-3-active, #0B1A26BA);
 }
 
-#section-footer .palette-three .footer__app .weglot-widget__dropdown--down {
+#section-footer .palette-three .footer__app .weglot-widget__dropdown {
   border-color: var(--color-border-3, #0B1A2626);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--up:before,
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+}
+
+#section-footer .palette-three .footer__app .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown--down:before,
 #section-footer .palette-three .footer__app .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary-3, #F4B841) transparent;
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
-}
-
-#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-3-hover, #0B1A26CC);
-}
-
-#section-footer .palette-three .footer__app .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-3-active, #0B1A26BA);
+  border-color: transparent transparent var(--color-border-3, #0B1A2626) transparent;
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-3-hover, #0B1A26CC) transparent;
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-3-active, #0B1A26BA) transparent;
 }
 
 #section-footer .palette-three .footer__app .weglot-widget__item:hover {

--- a/assets/header.css
+++ b/assets/header.css
@@ -831,6 +831,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   #section-header .palette-one .header__app .weglot-widget__dropdown {
     border-color: var(--color-border, #0B1A2626);
     background-color: var(--background-primary, #FFFFFF) !important;
+    box-shadow: 0 0 8px var(--color-border, #0B1A2626);
   }
 
   #section-header .palette-one .header__app .weglot-widget__dropdown:hover {
@@ -890,6 +891,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   #section-header .palette-two .header__app .weglot-widget__dropdown {
     border-color: var(--color-border-2, #FFFFFF47);
     background-color: var(--background-primary-2, #0B1A26) !important;
+    box-shadow: 0 0 8px var(--color-border-2, #FFFFFF47);
   }
 
   #section-header .palette-two .header__app .weglot-widget__dropdown:hover {
@@ -949,6 +951,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   #section-header .palette-three .header__app .weglot-widget__dropdown {
     border-color: var(--color-border-3, #0B1A2626);
     background-color: var(--background-primary-3, #F4B841) !important;
+    box-shadow: 0 0 8px var(--color-border-3, #0B1A2626);
   }
 
   #section-header .palette-three .header__app .weglot-widget__dropdown:hover {

--- a/assets/header.css
+++ b/assets/header.css
@@ -248,11 +248,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
 .header__app:has(.app-mobile) {
   display: flex;
-  margin: 20px 0;
-}
-
-.header__app:has(.app-mobile) + .menu__social {
-  margin-right: 20px;
+  margin: 18px var(--horizontal-padding, 16px);
 }
 
 #section-header .app-mobile .weglot-widget__wrapper {
@@ -264,32 +260,53 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-header .app-mobile .weglot-widget__dropdown--down {
-  top: auto;
-  bottom: calc(100% + 11px);
-  left: 50%;
-  transform: translate(-50%, 0);
+#section-header .app-mobile .weglot-widget__dropdown {
+  left: 0;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius-rounded);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-header .app-mobile .weglot-widget__dropdown--down:before,
-#section-header .app-mobile .weglot-widget__dropdown--down:after {
+#section-header .app-mobile .weglot-widget__dropdown--up {
+  top: auto;
+  bottom: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down {
+  bottom: auto;
+  top: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown:before,
+#section-header .app-mobile .weglot-widget__dropdown:after {
   content: "";
   position: absolute;
-  top: 100%;
-  left: 50%;
+  left: 32px;
   transform: translate(-50%, 0);
   width: 0px;
   height: 0px;
   border-style: solid;
-  border-width: 10px 10px 0 10px;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-#section-header .app-mobile .weglot-widget__dropdown--down:before {
+#section-header .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .app-mobile .weglot-widget__dropdown--up:after {
+  top: 100%;
+  border-width: 10px 10px 0 10px;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up:before {
   top: calc(100% + 1px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .app-mobile .weglot-widget__dropdown--down:after {
+  bottom: 100%;
+  border-width: 0 10px 10px 10px;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before {
+  bottom: calc(100% + 1px);
 }
 
 #section-header .app-mobile .weglot-widget__item {
@@ -374,33 +391,50 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   color: var(--color-outline-active, #F4B841BA);
 }
 
-#section-header .palette-one .app-mobile .weglot-widget__dropdown--down {
+#section-header .palette-one .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border, #0B1A2626);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown--down:before,
 #section-header .palette-one .app-mobile .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary, #FFFFFF) transparent;
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
-}
-
-#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-hover, #F4B841CC);
-}
-
-#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-active, #F4B841BA);
+  border-color: transparent transparent var(--color-border, #0B1A2626) transparent;
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-hover, #F4B841CC) transparent;
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-active, #F4B841BA) transparent;
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__item:hover {
@@ -488,33 +522,50 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   color: var(--color-outline-2-active, #F4B841BA);
 }
 
-#section-header .palette-two .app-mobile .weglot-widget__dropdown--down {
+#section-header .palette-two .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown--down:before,
 #section-header .palette-two .app-mobile .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary-2, #0B1A26) transparent;
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
-}
-
-#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-2-hover, #F4B841CC);
-}
-
-#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-2-active, #F4B841BA);
+  border-color: transparent transparent var(--color-border-2, #FFFFFF47) transparent;
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-2-hover, #F4B841CC) transparent;
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-2-active, #F4B841BA) transparent;
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__item:hover {
@@ -603,33 +654,50 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   color: var(--color-outline-3-active, #0B1A26BA);
 }
 
-#section-header .palette-three .app-mobile .weglot-widget__dropdown--down {
+#section-header .palette-three .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border-3, #0B1A2626);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--up:after {
+  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--up:before {
+  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--up:hover:before {
+  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--up:active:before {
+  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown--down:before,
 #section-header .palette-three .app-mobile .weglot-widget__dropdown--down:after {
-  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+  border-color: transparent transparent var(--background-primary-3, #F4B841) transparent;
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown--down:before {
-  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
-}
-
-#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:hover {
-  border-color: var(--color-outline-3-hover, #0B1A26CC);
-}
-
-#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:active {
-  border-color: var(--color-outline-3-active, #0B1A26BA);
+  border-color: transparent transparent var(--color-border-3, #0B1A2626) transparent;
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown--down:hover:before {
-  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-3-hover, #0B1A26CC) transparent;
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown--down:active:before {
-  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
+  border-color: transparent transparent var(--color-outline-3-active, #0B1A26BA) transparent;
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__item:hover {
@@ -680,6 +748,10 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     margin-right: 32px;
   }
 
+  .header__app:has(.app-mobile) {
+    display: none;
+  }
+
   header:has(.app-mobile) .header__app:has(.app-desktop) {
     display: block;
   }
@@ -698,8 +770,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   }
 
-  #section-header .header__app .weglot-widget__dropdown--down {
-    top: calc(100% + 11px);
+  #section-header .header__app .weglot-widget__dropdown {
     left: 50%;
     transform: translate(-50%, 0);
     border: 1px solid var(--color-border);
@@ -707,18 +778,40 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   }
 
-  #section-header .header__app .weglot-widget__dropdown--down:before,
-  #section-header .header__app .weglot-widget__dropdown--down:after {
+  #section-header .header__app .weglot-widget__dropdown--up {
+    bottom: calc(100% + 11px);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--down {
+    top: calc(100% + 11px);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown:before,
+  #section-header .header__app .weglot-widget__dropdown:after {
     content: "";
     position: absolute;
-    bottom: 100%;
     left: 50%;
     transform: translate(-50%, 0);
     width: 0px;
     height: 0px;
     border-style: solid;
-    border-width: 0 10px 10px 10px;
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before,
+  #section-header .header__app .weglot-widget__dropdown--up:after {
+    top: 100%;
+    border-width: 10px 10px 0 10px;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before {
+    top: calc(100% + 1px);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--down:before,
+  #section-header .header__app .weglot-widget__dropdown--down:after {
+    bottom: 100%;
+    border-width: 0 10px 10px 10px;
   }
 
   #section-header .header__app .weglot-widget__dropdown--down:before {
@@ -741,9 +834,34 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     color: var(--color-outline-active, #F4B841BA);
   }
 
-  #section-header .palette-one .header__app .weglot-widget__dropdown--down {
+  #section-header .palette-one .header__app .weglot-widget__dropdown {
     border-color: var(--color-border, #0B1A2626);
     background-color: var(--background-primary, #FFFFFF) !important;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline-hover, #F4B841CC);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown:active {
+    border-color: var(--color-outline-active, #F4B841BA);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:before,
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:after {
+    border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:before {
+    border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:hover:before {
+    border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:active:before {
+    border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
   }
 
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:before,
@@ -753,14 +871,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border, #0B1A2626) transparent;
-  }
-
-  #section-header .palette-one .header__app .weglot-widget__dropdown--down:hover {
-    border-color: var(--color-outline-hover, #F4B841CC);
-  }
-
-  #section-header .palette-one .header__app .weglot-widget__dropdown--down:active {
-    border-color: var(--color-outline-active, #F4B841BA);
   }
 
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:hover:before {
@@ -795,9 +905,34 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     color: var(--color-outline-2-active, #F4B841BA);
   }
 
-  #section-header .palette-two .header__app .weglot-widget__dropdown--down {
+  #section-header .palette-two .header__app .weglot-widget__dropdown {
     border-color: var(--color-border-2, #FFFFFF47);
     background-color: var(--background-primary-2, #0B1A26) !important;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline-2-hover, #F4B841CC);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown:active {
+    border-color: var(--color-outline-2-active, #F4B841BA);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:before,
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:after {
+    border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:before {
+    border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:hover:before {
+    border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:active:before {
+    border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
   }
 
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:before,
@@ -807,14 +942,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border-2, #FFFFFF47) transparent;
-  }
-
-  #section-header .palette-two .header__app .weglot-widget__dropdown--down:hover {
-    border-color: var(--color-outline-2-hover, #F4B841CC);
-  }
-
-  #section-header .palette-two .header__app .weglot-widget__dropdown--down:active {
-    border-color: var(--color-outline-2-active, #F4B841BA);
   }
 
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:hover:before {
@@ -849,9 +976,34 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     color: var(--color-outline-3-active, #0B1A26BA);
   }
 
-  #section-header .palette-three .header__app .weglot-widget__dropdown--down {
+  #section-header .palette-three .header__app .weglot-widget__dropdown {
     border-color: var(--color-border-3, #0B1A2626);
     background-color: var(--background-primary-3, #F4B841) !important;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline-3-hover, #0B1A26CC);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown:active {
+    border-color: var(--color-outline-3-active, #0B1A26BA);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:before,
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:after {
+    border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:before {
+    border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:hover:before {
+    border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:active:before {
+    border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
   }
 
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:before,
@@ -861,14 +1013,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border-3, #0B1A2626) transparent;
-  }
-
-  #section-header .palette-three .header__app .weglot-widget__dropdown--down:hover {
-    border-color: var(--color-outline-3-hover, #0B1A26CC);
-  }
-
-  #section-header .palette-three .header__app .weglot-widget__dropdown--down:active {
-    border-color: var(--color-outline-3-active, #0B1A26BA);
   }
 
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:hover:before {

--- a/assets/header.css
+++ b/assets/header.css
@@ -242,6 +242,60 @@
   display: block !important;
 }
 
+header:has(.app-mobile) .header__app:has(.app-desktop) {
+  display: none;
+}
+
+.header__app:has(.app-mobile) {
+  display: flex;
+  margin: 20px 0;
+}
+
+.header__app:has(.app-mobile) + .menu__social {
+  margin-right: 20px;
+}
+
+#section-header .app-mobile .weglot-widget__wrapper {
+  border-radius: var(--border-radius-dynamic);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__wrapper .weglot-widget__label {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down {
+  top: auto;
+  bottom: calc(100% + 11px);
+  left: 50%;
+  transform: translate(-50%, 0);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-rounded);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .app-mobile .weglot-widget__dropdown--down:after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 0px;
+  height: 0px;
+  border-style: solid;
+  border-width: 10px 10px 0 10px;
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before {
+  top: calc(100% + 1px);
+}
+
+#section-header .app-mobile .weglot-widget__item {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
 .palette-one .header__content {
   color: var(--color-primary, #0B1A26);
   background: var(--background-primary, #FFFFFF);
@@ -300,6 +354,63 @@
   color: var(--color-primary, #0B1A26);
 }
 
+#section-header .palette-one .app-mobile .weglot-widget__wrapper {
+  border-color: var(--color-border, #0B1A2626);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down {
+  border-color: var(--color-border, #0B1A2626);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-active, #F4B841BA);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__item:hover {
+  color: var(--color-outline-hover, #F4B841CC);
+}
+
+#section-header .palette-one .app-mobile .weglot-widget__item:active {
+  color: var(--color-outline-active, #F4B841BA);
+}
+
 .palette-two .header__content {
   color: var(--color-primary-2, #FFFFFF);
   background: var(--background-primary-2, #0B1A26);
@@ -355,6 +466,63 @@
 
 .palette-two .header__cart .fa-spinner-third {
   color: var(--color-primary-2, #FFFFFF);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__wrapper {
+  border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down {
+  border-color: var(--color-border-2, #FFFFFF47);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-2-active, #F4B841BA);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__item:hover {
+  color: var(--color-outline-2-hover, #F4B841CC);
+}
+
+#section-header .palette-two .app-mobile .weglot-widget__item:active {
+  color: var(--color-outline-2-active, #F4B841BA);
 }
 
 .palette-three .header__content {
@@ -415,13 +583,61 @@
   color: var(--color-primary-3, #0B1A26);
 }
 
-header:has(.app-mobile) .header__app:has(.app-desktop) {
-  display: none;
+#section-header .palette-three .app-mobile .weglot-widget__wrapper {
+  border-color: var(--color-border-3, #0B1A2626);
 }
 
-.header__app:has(.app-mobile) {
-  display: flex;
-  margin: var(--padding-bottom-mobile, 16px) var(--horizontal-padding, 16px);
+#section-header .palette-three .app-mobile .weglot-widget__wrapper:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__wrapper:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
+  color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__wrapper:active .weglot-widget__label {
+  color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down {
+  border-color: var(--color-border-3, #0B1A2626);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:after {
+  border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:before {
+  border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:hover {
+  border-color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:active {
+  border-color: var(--color-outline-3-active, #0B1A26BA);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:hover:before {
+  border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__dropdown--down:active:before {
+  border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__item:hover {
+  color: var(--color-outline-3-hover, #0B1A26CC);
+}
+
+#section-header .palette-three .app-mobile .weglot-widget__item:active {
+  color: var(--color-outline-3-active, #0B1A26BA);
 }
 
 @media (min-width: 576px) {
@@ -447,21 +663,236 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   .header__search-wrapper {
     min-width: 800px;
   }
-}
 
-@media (min-width: 1100px) and (hover: hover) {
-  .header__app:has(.app-mobile) {
-    display: none;
+  .header__search {
+    margin: 0;
   }
 
-  header:has(.app-mobile) .header__app:has(.app-desktop) {
-    display: initial;
+  .header__cart {
+    margin: 0 0 0 32px;
+  }
+
+  .header__cart:only-child {
+    margin: 0;
   }
 
   .header__app:has(.app-desktop) {
-    margin-right: var(--horizontal-padding, 16px);
+    margin-right: 32px;
   }
 
+  header:has(.app-mobile) .header__app:has(.app-desktop) {
+    display: block;
+  }
+
+  #section-header .header__app [data-short-names="true"] {
+    width: auto;
+  }
+
+  #section-header .header__app .weglot-widget__wrapper {
+    border-radius: var(--border-radius-dynamic);
+    padding: 0;
+    border: none;
+  }
+
+  #section-header .header__app .weglot-widget__label {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--down {
+    top: calc(100% + 11px);
+    left: 50%;
+    transform: translate(-50%, 0);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-rounded);
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--down:before,
+  #section-header .header__app .weglot-widget__dropdown--down:after {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 0px;
+    height: 0px;
+    border-style: solid;
+    border-width: 0 10px 10px 10px;
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--down:before {
+    bottom: calc(100% + 1px);
+  }
+
+  #section-header .header__app .weglot-widget__item {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__label {
+    color: var(--color-primary, #0B1A26);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline-hover, #F4B841CC);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__wrapper:active .weglot-widget__label {
+    color: var(--color-outline-active, #F4B841BA);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down {
+    border-color: var(--color-border, #0B1A2626);
+    background-color: var(--background-primary, #FFFFFF) !important;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:before,
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:after {
+    border-color: transparent transparent var(--background-primary, #FFFFFF) transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:before {
+    border-color: transparent transparent var(--color-border, #0B1A2626) transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:hover {
+    border-color: var(--color-outline-hover, #F4B841CC);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:active {
+    border-color: var(--color-outline-active, #F4B841BA);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline-hover, #F4B841CC) transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__dropdown--down:active:before {
+    border-color: transparent transparent var(--color-outline-active, #F4B841BA) transparent;
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__item {
+    color: var(--color-primary, #0B1A26);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__item:hover {
+    color: var(--color-outline-hover, #F4B841CC);
+  }
+
+  #section-header .palette-one .header__app .weglot-widget__item:active {
+    color: var(--color-outline-active, #F4B841BA);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__label {
+    color: var(--color-primary-2, #FFFFFF);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline-2-hover, #F4B841CC);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__wrapper:active .weglot-widget__label {
+    color: var(--color-outline-2-active, #F4B841BA);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down {
+    border-color: var(--color-border-2, #FFFFFF47);
+    background-color: var(--background-primary-2, #0B1A26) !important;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:before,
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:after {
+    border-color: transparent transparent var(--background-primary-2, #0B1A26) transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:before {
+    border-color: transparent transparent var(--color-border-2, #FFFFFF47) transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:hover {
+    border-color: var(--color-outline-2-hover, #F4B841CC);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:active {
+    border-color: var(--color-outline-2-active, #F4B841BA);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline-2-hover, #F4B841CC) transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__dropdown--down:active:before {
+    border-color: transparent transparent var(--color-outline-2-active, #F4B841BA) transparent;
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__item {
+    color: var(--color-primary-2, #FFFFFF);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__item:hover {
+    color: var(--color-outline-2-hover, #F4B841CC);
+  }
+
+  #section-header .palette-two .header__app .weglot-widget__item:active {
+    color: var(--color-outline-2-active, #F4B841BA);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__label {
+    color: var(--color-primary-3, #0B1A26);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline-3-hover, #0B1A26CC);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__wrapper:active .weglot-widget__label {
+    color: var(--color-outline-3-active, #0B1A26BA);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down {
+    border-color: var(--color-border-3, #0B1A2626);
+    background-color: var(--background-primary-3, #F4B841) !important;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:before,
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:after {
+    border-color: transparent transparent var(--background-primary-3, #F4B841) transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:before {
+    border-color: transparent transparent var(--color-border-3, #0B1A2626) transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:hover {
+    border-color: var(--color-outline-3-hover, #0B1A26CC);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:active {
+    border-color: var(--color-outline-3-active, #0B1A26BA);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline-3-hover, #0B1A26CC) transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__dropdown--down:active:before {
+    border-color: transparent transparent var(--color-outline-3-active, #0B1A26BA) transparent;
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__item {
+    color: var(--color-primary-3, #0B1A26);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__item:hover {
+    color: var(--color-outline-3-hover, #0B1A26CC);
+  }
+
+  #section-header .palette-three .header__app .weglot-widget__item:active {
+    color: var(--color-outline-3-active, #0B1A26BA);
+  }
+}
+
+@media (min-width: 1100px) and (hover: hover) {
   .header__content-inner {
     grid-template-columns: max-content 1fr max-content;
     grid-template-areas: "column-1 column-2 column-3";
@@ -492,18 +923,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   .header__search-input-wrapper.filled ~ .header__search-reset {
     opacity: 1;
     visibility: visible;
-  }
-
-  .header__search {
-    margin: 0;
-  }
-
-  .header__cart {
-    margin: 0 0 0 32px;
-  }
-
-  .header__cart:only-child {
-    margin: 0;
   }
 
   .header__mobile-menu-opener-left,

--- a/assets/header.css
+++ b/assets/header.css
@@ -252,7 +252,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 }
 
 #section-header .app-mobile .weglot-widget__wrapper {
-  border-radius: var(--border-radius-dynamic);
+  border-radius: var(--border-radius-dynamic, 0);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -262,8 +262,8 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
 #section-header .app-mobile .weglot-widget__dropdown {
   left: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-rounded);
+  border: 1px solid var(--color-border, #0B1A2626);
+  border-radius: var(--border-radius-rounded, 0);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -393,6 +393,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border, #0B1A2626);
+  box-shadow: 0 0 8px var(--color-border, #0B1A2626);
 }
 
 #section-header .palette-one .app-mobile .weglot-widget__dropdown:hover {
@@ -524,6 +525,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border-2, #FFFFFF47);
+  box-shadow: 0 0 8px var(--color-border-2, #FFFFFF47);
 }
 
 #section-header .palette-two .app-mobile .weglot-widget__dropdown:hover {
@@ -656,6 +658,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown {
   border-color: var(--color-border-3, #0B1A2626);
+  box-shadow: 0 0 8px var(--color-border-3, #0B1A2626);
 }
 
 #section-header .palette-three .app-mobile .weglot-widget__dropdown:hover {
@@ -761,7 +764,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .header__app .weglot-widget__wrapper {
-    border-radius: var(--border-radius-dynamic);
+    border-radius: var(--border-radius-dynamic, 0);
     padding: 0;
     border: none;
   }
@@ -773,17 +776,15 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   #section-header .header__app .weglot-widget__dropdown {
     left: 50%;
     transform: translate(-50%, 0);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius-rounded);
+    border: 1px solid var(--color-border, #0B1A2626);
+    border-radius: var(--border-radius-rounded, 0);
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   }
 
-  #section-header .header__app .weglot-widget__dropdown--up {
-    bottom: calc(100% + 11px);
-  }
-
+  #section-header .header__app .weglot-widget__dropdown--up,
   #section-header .header__app .weglot-widget__dropdown--down {
     top: calc(100% + 11px);
+    bottom: auto;
   }
 
   #section-header .header__app .weglot-widget__dropdown:before,
@@ -799,21 +800,14 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .header__app .weglot-widget__dropdown--up:before,
-  #section-header .header__app .weglot-widget__dropdown--up:after {
-    top: 100%;
-    border-width: 10px 10px 0 10px;
-  }
-
-  #section-header .header__app .weglot-widget__dropdown--up:before {
-    top: calc(100% + 1px);
-  }
-
+  #section-header .header__app .weglot-widget__dropdown--up:after,
   #section-header .header__app .weglot-widget__dropdown--down:before,
   #section-header .header__app .weglot-widget__dropdown--down:after {
     bottom: 100%;
     border-width: 0 10px 10px 10px;
   }
 
+  #section-header .header__app .weglot-widget__dropdown--up:before,
   #section-header .header__app .weglot-widget__dropdown--down:before {
     bottom: calc(100% + 1px);
   }
@@ -848,35 +842,23 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .palette-one .header__app .weglot-widget__dropdown--up:before,
-  #section-header .palette-one .header__app .weglot-widget__dropdown--up:after {
-    border-color: var(--background-primary, #FFFFFF) transparent transparent transparent;
-  }
-
-  #section-header .palette-one .header__app .weglot-widget__dropdown--up:before {
-    border-color: var(--color-border, #0B1A2626) transparent transparent transparent;
-  }
-
-  #section-header .palette-one .header__app .weglot-widget__dropdown--up:hover:before {
-    border-color: var(--color-outline-hover, #F4B841CC) transparent transparent transparent;
-  }
-
-  #section-header .palette-one .header__app .weglot-widget__dropdown--up:active:before {
-    border-color: var(--color-outline-active, #F4B841BA) transparent transparent transparent;
-  }
-
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:after,
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:before,
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:after {
     border-color: transparent transparent var(--background-primary, #FFFFFF) transparent;
   }
 
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:before,
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border, #0B1A2626) transparent;
   }
 
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:hover:before,
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:hover:before {
     border-color: transparent transparent var(--color-outline-hover, #F4B841CC) transparent;
   }
 
+  #section-header .palette-one .header__app .weglot-widget__dropdown--up:active:before,
   #section-header .palette-one .header__app .weglot-widget__dropdown--down:active:before {
     border-color: transparent transparent var(--color-outline-active, #F4B841BA) transparent;
   }
@@ -919,35 +901,23 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .palette-two .header__app .weglot-widget__dropdown--up:before,
-  #section-header .palette-two .header__app .weglot-widget__dropdown--up:after {
-    border-color: var(--background-primary-2, #0B1A26) transparent transparent transparent;
-  }
-
-  #section-header .palette-two .header__app .weglot-widget__dropdown--up:before {
-    border-color: var(--color-border-2, #FFFFFF47) transparent transparent transparent;
-  }
-
-  #section-header .palette-two .header__app .weglot-widget__dropdown--up:hover:before {
-    border-color: var(--color-outline-2-hover, #F4B841CC) transparent transparent transparent;
-  }
-
-  #section-header .palette-two .header__app .weglot-widget__dropdown--up:active:before {
-    border-color: var(--color-outline-2-active, #F4B841BA) transparent transparent transparent;
-  }
-
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:after,
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:before,
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:after {
     border-color: transparent transparent var(--background-primary-2, #0B1A26) transparent;
   }
 
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:before,
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border-2, #FFFFFF47) transparent;
   }
 
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:hover:before,
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:hover:before {
     border-color: transparent transparent var(--color-outline-2-hover, #F4B841CC) transparent;
   }
 
+  #section-header .palette-two .header__app .weglot-widget__dropdown--up:active:before,
   #section-header .palette-two .header__app .weglot-widget__dropdown--down:active:before {
     border-color: transparent transparent var(--color-outline-2-active, #F4B841BA) transparent;
   }
@@ -990,35 +960,23 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .palette-three .header__app .weglot-widget__dropdown--up:before,
-  #section-header .palette-three .header__app .weglot-widget__dropdown--up:after {
-    border-color: var(--background-primary-3, #F4B841) transparent transparent transparent;
-  }
-
-  #section-header .palette-three .header__app .weglot-widget__dropdown--up:before {
-    border-color: var(--color-border-3, #0B1A2626) transparent transparent transparent;
-  }
-
-  #section-header .palette-three .header__app .weglot-widget__dropdown--up:hover:before {
-    border-color: var(--color-outline-3-hover, #0B1A26CC) transparent transparent transparent;
-  }
-
-  #section-header .palette-three .header__app .weglot-widget__dropdown--up:active:before {
-    border-color: var(--color-outline-3-active, #0B1A26BA) transparent transparent transparent;
-  }
-
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:after,
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:before,
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:after {
     border-color: transparent transparent var(--background-primary-3, #F4B841) transparent;
   }
 
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:before,
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:before {
     border-color: transparent transparent var(--color-border-3, #0B1A2626) transparent;
   }
 
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:hover:before,
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:hover:before {
     border-color: transparent transparent var(--color-outline-3-hover, #0B1A26CC) transparent;
   }
 
+  #section-header .palette-three .header__app .weglot-widget__dropdown--up:active:before,
   #section-header .palette-three .header__app .weglot-widget__dropdown--down:active:before {
     border-color: transparent transparent var(--color-outline-3-active, #0B1A26BA) transparent;
   }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -134,12 +134,6 @@
   {%- if facebook != blank or instagram != blank or twitter != blank or linkedin != blank or pinterest != blank or tiktok != blank or tumblr != blank or snapchat != blank or youtube != blank or vimeo != blank -%}
     <div class="menu__bottom">
       <div class="menu__icons">
-        {%- if app -%}
-          <div class="header__app">
-            {% render 'app', block: app, section: section, size: "mobile" %}
-          </div>
-        {%- endif -%}
-
         <div class="menu__social">
           {%- render "socials", settings: settings -%}
         </div>
@@ -254,6 +248,12 @@
               {%- endif -%}
 
             {%- endfor -%}
+
+            {%- if app -%}
+              <li class="header__app">
+                {% render 'app', block: app, section: section, size: "mobile" %}
+              </li>
+            {%- endif -%}
           </ul>
 
           {{- social_icons -}}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -134,6 +134,12 @@
   {%- if facebook != blank or instagram != blank or twitter != blank or linkedin != blank or pinterest != blank or tiktok != blank or tumblr != blank or snapchat != blank or youtube != blank or vimeo != blank -%}
     <div class="menu__bottom">
       <div class="menu__icons">
+        {%- if app -%}
+          <div class="header__app">
+            {% render 'app', block: app, section: section, size: "mobile" %}
+          </div>
+        {%- endif -%}
+
         <div class="menu__social">
           {%- render "socials", settings: settings -%}
         </div>
@@ -248,12 +254,6 @@
               {%- endif -%}
 
             {%- endfor -%}
-
-            {%- if app -%}
-              <li class="header__app">
-                {% render 'app', block: app, section: section, size: "mobile" %}
-              </li>
-            {%- endif -%}
           </ul>
 
           {{- social_icons -}}


### PR DESCRIPTION
The Weglot app has been using its own styles that look not good on some screen resolutions. Besides that, it doesn't use theme's variables which can take different values depending on theme settings

This PR is intended to add styles, make the app responsive, and fit into the overall design.

Before:

Header light:
![Arc_2024-04-29 18-58-52@2x](https://github.com/booqable/tough-theme/assets/40244261/15b3d514-a6d3-4cbf-ab4e-0f7574130a15)

Header dark:
![Arc_2024-04-29 18-52-24@2x](https://github.com/booqable/tough-theme/assets/40244261/d92b95ed-6ee5-4808-bacf-e94d2cb59f56)

Footer light:
![Arc_2024-04-29 18-51-25@2x](https://github.com/booqable/tough-theme/assets/40244261/5a9464e5-4818-4843-b263-63e93cfa0c4b)

Footer dark:
![Arc_2024-04-29 18-52-51@2x](https://github.com/booqable/tough-theme/assets/40244261/f43295cb-30fb-469b-ab40-7c77f6a57b12)


After:
Header:
![Arc_2024-04-29 14-27-45@2x](https://github.com/booqable/tough-theme/assets/40244261/6b7d5e06-8a46-440e-8549-6998f31156b9)


Footer:
![Arc_2024-04-29 14-29-51@2x](https://github.com/booqable/tough-theme/assets/40244261/1ab74409-2d4e-4ff8-9efc-9149d454b710)

Testing clue: For activating the EN button, the Veglot app should be added to your Booqable account from the App store and then added as a block in the header/footer via the theme editor
![Arc_2024-04-29 10-03-00@2x](https://github.com/booqable/tough-theme/assets/40244261/a0019f93-22e2-42ec-b87e-a79c046d0e34)

