### PR TITLE
Fix horizontal menu if it has a lot of items

### DIFF
--- a/assets/mega-menu.css
+++ b/assets/mega-menu.css
@@ -976,6 +976,7 @@
   .menu-wide.mobile-menu-top .menu__dropdown-list,
   .menu-wide .menu__dropdown-list {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .menu-wide .menu__dropdown-item {


### PR DESCRIPTION
The customer reported the issue with a menu with a lot of items.
When it's set up to horizontal the menu background is not applied to all the options and items go off the edges of the screen.

Before:
![image](https://github.com/booqable/tough-theme/assets/40244261/17c41c4f-b93d-43ab-917e-8391ebbb7e62)


After:
![Arc_2024-05-08 18-07-10@2x](https://github.com/booqable/tough-theme/assets/40244261/a782e9e7-c86b-4502-a28d-49218911f30c)

