### PR TITLE
Add `no-descending-specificity` rule to Stylelint configuration

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,6 +6,7 @@
       {
         "message": "Expected class selector to be kebab-case with optional BEM notation."
       }
-    ]
+    ],
+    "no-descending-specificity": null
   }
 }


### PR DESCRIPTION
This pull request updates the `.stylelintrc.json` configuration file to disable the `no-descending-specificity` rule. This change allows styles with descending specificity to pass linting without errors.