### PR TITLE
Fix `overlay opacity` calculations after the Stylelint auto-fixes

### DIFF
--- a/sections/call-to-action.liquid
+++ b/sections/call-to-action.liquid
@@ -17,7 +17,7 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
-  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+  --overlay-opacity: {{ overlay_opacity | divided_by: 100.0 }};
 
   {%- case padding_top -%}
       {%- when 'none' -%}

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -21,7 +21,7 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
-  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+  --overlay-opacity: {{ overlay_opacity | divided_by: 100.0 }};
 
   {%- case padding_top -%}
     {%- when 'small' -%}

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -18,7 +18,7 @@
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
-  --overlay-opacity: {{ overlay_opacity | append: '%' }};
+  --overlay-opacity: {{ overlay_opacity | divided_by: 100.0 }};
 
   {%- case padding_top -%}
     {%- when 'small' -%}

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -311,10 +311,10 @@
 
             {%- if show_overlay -%}
               {%- capture image_variables -%}
-                --opacity-overlay: {{ overlay_opacity | append: "%"}};
-                --background-overlay: {{- overlay_background -}};
-                --background-overlay-00: {{- overlay_background | append: "00" -}};
-                --background-overlay-45: {{- overlay_background | append: "73" -}};
+                --opacity-overlay: {{ overlay_opacity | divided_by: 100.0 }};
+                --background-overlay: {{ overlay_background }};
+                --background-overlay-00: {{ overlay_background | append: "00" }};
+                --background-overlay-45: {{ overlay_background | append: "73" }};
               {%- endcapture -%}
             {%- endif -%}
             {% comment %} CSS variables end {% endcomment %}


### PR DESCRIPTION
This PR fixes the calculation of CSS variables for overlay opacity across multiple sections after Stylelint auto-fixes. The change replaces the use of the `append` filter with the `divided_by` filter to ensure the opacity values are correctly formatted as decimals instead of percentages.

Updates to CSS variable calculations:

* [`sections/call-to-action.liquid`](diffhunk://#diff-c99f31ad317f11ceb1548470dad41191e9af090151bb5e1ad3906732540e8446L20-R20): Changed `overlay_opacity` calculation from appending '%' to dividing by 100.0 for proper decimal formatting.
* [`sections/hero-search.liquid`](diffhunk://#diff-44d37ca3f0e9528675970f6a6eda145a9b392931d999d3152bc1480f450b4786L24-R24): Updated `overlay_opacity` calculation to use division by 100.0 instead of appending '%'.
* [`sections/hero.liquid`](diffhunk://#diff-9308c289699093b6a7410187022a969407a33f05832124b2bc6decbbf852efd9L21-R21): Adjusted `overlay_opacity` calculation to divide by 100.0 for consistency with other sections.
* [`sections/images.liquid`](diffhunk://#diff-5ff298e3d1cbde27427a1177150109a1ab8371e1f6a288690157bf631b0640b3L314-R317): Modified `opacity-overlay` calculation to use division by 100.0 and ensured other overlay-related variables retain their formatting.