### PR TITLE
Variation label not translatable

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -10,7 +10,7 @@
 {%- assign quantity                      = product | product_button -%}
 {%- assign price                         = product | product_price -%}
 {%- assign period                        = product | product_price_label -%}
-{%- assign variation_label               = section.settings.variation_label -%}
+{%- assign variation_label               = 'store.variant' | user_t | default: section.settings.variation_label -%}
 {%- assign message_label                 = section.settings.message_label -%}
 {%- assign show_controls                 = section.settings.show_controls -%}
 {%- assign show_thumbnails               = section.settings.show_thumbnails -%}
@@ -158,12 +158,6 @@
       {
         "type": "header",
         "content": "General settings"
-      },
-      {
-        "type": "text",
-        "id": "variation_label",
-        "label": "Variations label",
-        "default": "Variation"
       },
       {
         "type": "text",


### PR DESCRIPTION
## Why

We are removing the option to change the `variant_label`, it will be handled by user translations

## Link

[Variation label not translatable](https://linear.app/booqable/issue/SC-1698/variation-label-not-translatable)