### PR TITLE
Fix requestIdle callback in handleMegaMenu for proper event binding

### DIFF
--- a/assets/js-header-menu.js
+++ b/assets/js-header-menu.js
@@ -309,7 +309,7 @@ const handleMegaMenu = () => {
 
   MegaMenuState.init(header)
 
-  $.slowConnection() ? MegaMenuEvents.bindEvents() : $.requestIdle(MegaMenuEvents.bindEvents())
+  $.slowConnection() ? MegaMenuEvents.bindEvents() : $.requestIdle(() => MegaMenuEvents.bindEvents())
 
   const cleanup = () => {
     MegaMenuEvents.cleanup()


### PR DESCRIPTION
This PR updates the event binding logic in the `handleMegaMenu` function. The change ensures that `MegaMenuEvents.bindEvents` is invoked as a function within `$.requestIdle`, rather than being passed as a reference. This prevents potential issues with how the function is executed.

<img width="778" height="116" alt="Arc 2025-08-20 13 26 08" src="https://github.com/user-attachments/assets/2eb02c56-6d09-4922-9ca4-ab92ecc87fb4" />
