### PR TITLE
Remove extra div in `Text with image` section

### DIFF
--- a/sections/text-with-image.liquid
+++ b/sections/text-with-image.liquid
@@ -180,17 +180,15 @@
       {%- if image.url != blank -%}
         <div class="text-image__col">
           <div class="text-image__holder">
-            <div class="text-image__image-wrapper">
-              {%- if image.url != blank -%}
-                {%- render 'image',
-                  image: image,
-                  image_alt: image_alt,
-                  image_class: 'text-image__image',
-                  image_size: 'm',
-                  loading: loading_strategy
-                -%}
-              {%- endif -%}
-            </div>
+            {%- if image.url != blank -%}
+              {%- render 'image',
+                image: image,
+                image_alt: image_alt,
+                image_class: 'text-image__image',
+                image_size: 'm',
+                loading: loading_strategy
+              -%}
+            {%- endif -%}
           </div>
         </div>
       {%- endif -%}


### PR DESCRIPTION
This PR aims to align the image in section to avoid text overlapping


### Before:
<img width="1893" height="945" alt="Arc 2025-08-22 13 27 26" src="https://github.com/user-attachments/assets/a4e4f05e-2aca-4e1f-bd5c-ccafe56e0602" />



### After:
<img width="1944" height="922" alt="Arc 2025-08-22 13 41 01" src="https://github.com/user-attachments/assets/41223864-af30-465e-998c-313ad3c6af02" />

